### PR TITLE
Feature/transition to multiple states / transition as decorator

### DIFF
--- a/.checkignore
+++ b/.checkignore
@@ -1,0 +1,3 @@
+tests/*
+
+travis_pypi_setup.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,6 @@
 [run]
 branch = True
 data_file = .coverage
-parallel = False
 source =
     statemachine
 omit =
@@ -10,6 +9,7 @@ omit =
     pytest_cov
 
 [report]
+show_missing = True
 exclude_lines =
     # Have to re-enable the standard pragma
     pragma: no cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,11 @@ deploy:
     secure: i68HiBr+uLUc3cWFVs6ZyGJ9L+/RFtqKFPPIqGuWKCBfSNOjUu5VHsejKQ9nhJaOPp3VIzgXfE+1KntWYA+fDeZgHxitxodtdax5th810K/OQRqdrPUoJW6liJ4/BhRuUCXwCSrvGfhOiBH3kLTXiXgZ64gnCSeHGd2DZubvzUpiGA9638F5mV7UitkKfB+NKPNxO07IDYGDe8nvk8Yx9KbOuwgQ67O79x9DI8/JJGJsgI86wYyOLUhnhoJVRXXg7T5jLSe8CL3qYFoxoLE2MgTehfwt46Jqh3ERHTIENhJSECBTZeZg2xTSbR1iCRSWbjwoM51iiMUD0eE4jNRVpBgqaSao7yjRSgtHMsAHrRUHiqC7xELB5yHGea6qnTQk1NEu+lvlgM5bEkXn6UNYq9hYVPgykaAoJebzUJqYkQKTkpzHU9Ol6A2IRAFA30WLHUFZA/BwilT8+P8gOC9ESztSruzIhj0zdavGmAFaIW0/82wj7P23/ySZFvBJYD3+r3DBDEsXD85eguoIDq+MDFgKfOwOL8RY8U5WHPsCDx3betOUGDqOyK8hzJBYwSQd63R0WKI3XS9pVNDp2kF1DG4HvDUVFk5Mitaxxyg9LbSl1+WtXzQJbNOh6W41pl+gRdKl+PMk3kjeLsk8sZ/1cIO6lkzFBdzOPTf65H/rpWA=
   provider: pypi
   user: fgmacedo
-env:
-- TOXENV=py36
-- TOXENV=py35
-- TOXENV=py34
-- TOXENV=py27
 before_install:
   - pip install -U pytest
   - pip install codecov
   - pip install -e .
-install: pip install -U tox
+install: pip install -U tox-travis
 language: python
 python:
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,11 @@ before_install:
   - pip install -e .
 install: pip install -U tox
 language: python
-python: 3.6
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
 script: tox -e ${TOXENV}
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ python:
   - 3.4
   - 3.5
   - 3.6
-script: tox -e ${TOXENV}
+script: tox
 after_success:
   - codecov

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 
 * Python 3.6 support.
 * Drop official support for Python 3.3.
+* `Transition` can be used as decorator for `on_execute` callback definition.
 
 
 0.3.0 (2017-03-22)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 * Python 3.6 support.
 * Drop official support for Python 3.3.
 * `Transition` can be used as decorator for `on_execute` callback definition.
+* `Transition` can point to multiple destination states.
 
 
 0.3.0 (2017-03-22)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,5 @@
 tox==2.7.0
+mock==2.0.0
 pytest==3.1.3
 pytest-cov==2.5.1
 pytest-pep8==1.0.6

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -52,6 +52,9 @@ class CallableInstance(object):
 
 
 class Transition(object):
+    """
+    A transition holds reference to the source and destinations states.
+    """
 
     def __init__(self, *states, **options):
         self.source = states[0]
@@ -157,9 +160,8 @@ class CombinedTransition(Transition):
 
     def __call__(self, f):
         result = super(CombinedTransition, self).__call__(f)
-        if self.on_execute:
-            self._left.on_execute = self.on_execute
-            self._right.on_execute = self.on_execute
+        self._left.on_execute = self.on_execute
+        self._right.on_execute = self.on_execute
         return result
 
     def __contribute_to_class__(self, managed, identifier):

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -155,6 +155,13 @@ class CombinedTransition(Transition):
     def _right(self):
         return self.destinations[0]
 
+    def __call__(self, f):
+        result = super(CombinedTransition, self).__call__(f)
+        if self.on_execute:
+            self._left.on_execute = self.on_execute
+            self._right.on_execute = self.on_execute
+        return result
+
     def __contribute_to_class__(self, managed, identifier):
         super(CombinedTransition, self).__contribute_to_class__(managed, identifier)
         self._left.__contribute_to_class__(managed, identifier)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,3 +35,27 @@ def campaign_machine_with_values():
         deliver = producing.to(closed)
 
     return CampaignMachineWithKeys
+
+
+@pytest.fixture
+def traffic_light_machine():
+    from statemachine import StateMachine, State
+
+    class TrafficLightMachine(StateMachine):
+        green = State('Green', initial=True)
+        yellow = State('Yellow')
+        red = State('Red')
+
+        @green.to(yellow)
+        def slowdown(self, *args, **kwargs):
+            return args, kwargs
+
+        @yellow.to(red)
+        def stop(self, *args, **kwargs):
+            return args, kwargs
+
+        @red.to(green)
+        def go(self, *args, **kwargs):
+            return args, kwargs
+
+    return TrafficLightMachine

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ def campaign_machine():
     from statemachine import State, StateMachine
 
     class CampaignMachine(StateMachine):
+        "A workflow machine"
         draft = State('Draft', initial=True)
         producing = State('Being produced')
         closed = State('Closed')
@@ -32,6 +33,7 @@ def campaign_machine_with_values():
     from statemachine import State, StateMachine
 
     class CampaignMachineWithKeys(StateMachine):
+        "A workflow machine"
         draft = State('Draft', initial=True, value=1)
         producing = State('Being produced', value=2)
         closed = State('Closed', value=3)
@@ -48,6 +50,7 @@ def traffic_light_machine():
     from statemachine import StateMachine, State
 
     class TrafficLightMachine(StateMachine):
+        "A traffic light machine"
         green = State('Green', initial=True)
         yellow = State('Yellow')
         red = State('Red')
@@ -72,6 +75,7 @@ def approval_machine(current_time):
     from statemachine import StateMachine, State
 
     class ApprovalMachine(StateMachine):
+        "A workflow machine"
         requested = State('Requested', initial=True)
         accepted = State('Accepted')
         rejected = State('Rejected')

--- a/tests/test_callable_instance.py
+++ b/tests/test_callable_instance.py
@@ -1,0 +1,19 @@
+# coding: utf-8
+from __future__ import absolute_import, unicode_literals
+
+import mock
+
+from statemachine.statemachine import CallableInstance
+
+
+def test_callable_should_override_kwargs():
+    target = mock.MagicMock(wil_be_overrided=1, will_be_proxied=2, z='text')
+    proxy = CallableInstance(target, func=target.a_func, wil_be_overrided=3)
+
+    assert proxy.wil_be_overrided == 3
+    assert proxy.will_be_proxied == 2
+    assert proxy.z == 'text'
+
+    proxy(4, 5, k=6)
+
+    target.a_func.assert_called_once_with(4, 5, k=6)

--- a/tests/test_multiple_destinations.py
+++ b/tests/test_multiple_destinations.py
@@ -1,0 +1,119 @@
+# coding: utf-8
+from __future__ import absolute_import, unicode_literals
+
+import pytest
+import mock
+
+from statemachine import StateMachine, State
+
+
+def test_transition_should_choose_final_state_on_multiple_possibilities(
+        approval_machine, current_time):
+    # given
+    model = mock.MagicMock(
+        state='requested',
+        accepted_at=None,
+        rejected_at=None,
+        completed_at=None,
+    )
+    machine = approval_machine(model)
+
+    model.is_ok.return_value = False
+
+    # when
+    assert machine.validate() == model
+
+    # then
+    assert model.rejected_at == current_time
+    assert machine.is_rejected
+
+    # given
+    model.is_ok.return_value = True
+
+    # when
+    assert machine.retry() == model
+
+    # then
+    assert model.rejected_at is None
+    assert machine.is_requested
+
+    # when
+    assert machine.validate() == model
+
+    # then
+    assert model.accepted_at == current_time
+    assert machine.is_accepted
+
+
+def test_should_raise_error_if_not_define_callback_in_multiple_destinations():
+    class ApprovalMachine(StateMachine):
+        requested = State('Requested', initial=True)
+        accepted = State('Accepted')
+        rejected = State('Rejected')
+
+        validate = requested.to(accepted, rejected)
+
+    machine = ApprovalMachine()
+
+    with pytest.raises(ValueError) as e:
+        machine.validate()
+
+        assert 'desired state' in e.message
+
+
+@pytest.mark.parametrize('return_value', [
+    None,
+    1,
+    (2, 3),
+    (4, 5, 6),
+    ((7, 8), 9),
+])
+def test_should_raise_error_if_not_inform_state_in_multiple_destinations(return_value):
+    class ApprovalMachine(StateMachine):
+        requested = State('Requested', initial=True)
+        accepted = State('Accepted')
+        rejected = State('Rejected')
+
+        @requested.to(accepted, rejected)
+        def validate(self):
+            return return_value
+
+    machine = ApprovalMachine()
+
+    with pytest.raises(ValueError) as e:
+        machine.validate()
+
+        assert 'desired state' in e.message
+
+
+def test_should_raise_error_if_returned_state_is_not_a_possible_destination():
+    class ApprovalMachine(StateMachine):
+        requested = State('Requested', initial=True)
+        accepted = State('Accepted')
+        rejected = State('Rejected')
+
+        @requested.to(accepted, rejected)
+        def validate(self):
+            return self.requested
+
+    machine = ApprovalMachine()
+
+    with pytest.raises(ValueError) as e:
+        machine.validate()
+
+        assert 'desired state' in e.message
+
+
+def test_should_change_to_returned_state_on_multiple_destination():
+    class ApprovalMachine(StateMachine):
+        requested = State('Requested', initial=True)
+        accepted = State('Accepted')
+        rejected = State('Rejected')
+
+        @requested.to(accepted, rejected)
+        def validate(self):
+            return self.accepted
+
+    machine = ApprovalMachine()
+
+    assert machine.validate() is None

--- a/tests/test_multiple_destinations.py
+++ b/tests/test_multiple_destinations.py
@@ -169,3 +169,17 @@ def test_should_change_to_returned_state_on_multiple_destination_with_combined_t
     with pytest.raises(LookupError) as e:
         assert machine.validate()
         assert e.message == "Can't validate when in Completed."
+
+
+def test_transition_on_execute_should_be_called_with_run_syntax(approval_machine, current_time):
+    # given
+    model = mock.MagicMock(state='requested', accepted_at=None,)
+    machine = approval_machine(model)
+
+    model.is_ok.return_value = True
+
+    # when
+    assert machine.run('validate') == model
+    # then
+    assert model.accepted_at == current_time
+    assert machine.is_accepted

--- a/tests/test_multiple_destinations.py
+++ b/tests/test_multiple_destinations.py
@@ -47,6 +47,7 @@ def test_transition_should_choose_final_state_on_multiple_possibilities(
 
 def test_should_raise_error_if_not_define_callback_in_multiple_destinations():
     class ApprovalMachine(StateMachine):
+        "A workflow"
         requested = State('Requested', initial=True)
         accepted = State('Accepted')
         rejected = State('Rejected')
@@ -67,34 +68,19 @@ def test_should_raise_error_if_not_define_callback_in_multiple_destinations():
     (2, 3),
     (4, 5, 6),
     ((7, 8), 9),
+    'requested'
 ])
 def test_should_raise_error_if_not_inform_state_in_multiple_destinations(return_value):
     class ApprovalMachine(StateMachine):
+        "A workflow"
         requested = State('Requested', initial=True)
         accepted = State('Accepted')
         rejected = State('Rejected')
 
         @requested.to(accepted, rejected)
         def validate(self):
-            return return_value
-
-    machine = ApprovalMachine()
-
-    with pytest.raises(ValueError) as e:
-        machine.validate()
-
-        assert 'desired state' in e.message
-
-
-def test_should_raise_error_if_returned_state_is_not_a_possible_destination():
-    class ApprovalMachine(StateMachine):
-        requested = State('Requested', initial=True)
-        accepted = State('Accepted')
-        rejected = State('Rejected')
-
-        @requested.to(accepted, rejected)
-        def validate(self):
-            return self.requested
+            "tries to get an attr (like a desired state), failsback to the `return_value` itself"
+            return getattr(self, str(return_value), return_value)
 
     machine = ApprovalMachine()
 
@@ -106,6 +92,7 @@ def test_should_raise_error_if_returned_state_is_not_a_possible_destination():
 
 def test_should_change_to_returned_state_on_multiple_destination():
     class ApprovalMachine(StateMachine):
+        "A workflow"
         requested = State('Requested', initial=True)
         accepted = State('Accepted')
         rejected = State('Rejected')
@@ -122,6 +109,7 @@ def test_should_change_to_returned_state_on_multiple_destination():
 
 def test_should_change_to_returned_state_on_multiple_destination_with_combined_transitions():
     class ApprovalMachine(StateMachine):
+        "A workflow"
         requested = State('Requested', initial=True)
         accepted = State('Accepted')
         rejected = State('Rejected')

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -43,9 +43,11 @@ def test_machine_should_only_allow_only_one_initial_state():
 def test_transition_representation(campaign_machine):
     s = repr([t for t in campaign_machine.transitions if t.identifier == 'produce'][0])
     print(s)
-    assert s == ("Transition("
-                 "State('Draft', identifier='draft', value='draft', initial=True), "
-                 "State('Being produced', identifier='producing', value='producing', initial=False), identifier='produce')")
+    assert s == (
+        "Transition("
+         "State('Draft', identifier='draft', value='draft', initial=True), "
+         "(State('Being produced', identifier='producing', value='producing', initial=False),), identifier='produce')"
+    )
 
 
 def test_should_change_state(campaign_machine):

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -3,7 +3,6 @@
 import pytest
 
 from statemachine import StateMachine, State
-from .conftest import campaign_machine, campaign_machine_with_values
 
 
 class MyModel(object):
@@ -255,26 +254,28 @@ def test_state_machine_without_model(campaign_machine):
     assert not machine.is_closed
 
 
-@pytest.mark.parametrize('model, machine_cls, start_value', [
-    (None, campaign_machine(), 'producing'),
-    (None, campaign_machine_with_values(), 2),
-    (MyModel(), campaign_machine(), 'producing'),
-    (MyModel(), campaign_machine_with_values(), 2),
+@pytest.mark.parametrize('model, machine_name, start_value', [
+    (None, 'campaign_machine', 'producing'),
+    (None, 'campaign_machine_with_values', 2),
+    (MyModel(), 'campaign_machine', 'producing'),
+    (MyModel(), 'campaign_machine_with_values', 2),
 ])
-def test_state_machine_with_a_start_value(model, machine_cls, start_value):
+def test_state_machine_with_a_start_value(model, machine_name, start_value):
+    machine_cls = pytest.getfixturevalue(machine_name)
     machine = machine_cls(model, start_value=start_value)
     assert not machine.is_draft
     assert machine.is_producing
     assert not model or model.state == start_value
 
 
-@pytest.mark.parametrize('model, machine_cls, start_value', [
-    (None, campaign_machine(), 'tapioca'),
-    (None, campaign_machine_with_values(), 99),
-    (MyModel(), campaign_machine(), 'tapioca'),
-    (MyModel(), campaign_machine_with_values(), 99),
+@pytest.mark.parametrize('model, machine_name, start_value', [
+    (None, 'campaign_machine', 'tapioca'),
+    (None, 'campaign_machine_with_values', 99),
+    (MyModel(), 'campaign_machine', 'tapioca'),
+    (MyModel(), 'campaign_machine_with_values', 99),
 ])
-def test_state_machine_with_a_invalid_start_value(model, machine_cls, start_value):
+def test_state_machine_with_a_invalid_start_value(model, machine_name, start_value):
+    machine_cls = pytest.getfixturevalue(machine_name)
     with pytest.raises(ValueError):
         machine_cls(model, start_value=start_value)
 

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -260,8 +260,8 @@ def test_state_machine_without_model(campaign_machine):
     (MyModel(), 'campaign_machine', 'producing'),
     (MyModel(), 'campaign_machine_with_values', 2),
 ])
-def test_state_machine_with_a_start_value(model, machine_name, start_value):
-    machine_cls = pytest.getfixturevalue(machine_name)
+def test_state_machine_with_a_start_value(request, model, machine_name, start_value):
+    machine_cls = request.getfixturevalue(machine_name)
     machine = machine_cls(model, start_value=start_value)
     assert not machine.is_draft
     assert machine.is_producing
@@ -274,8 +274,8 @@ def test_state_machine_with_a_start_value(model, machine_name, start_value):
     (MyModel(), 'campaign_machine', 'tapioca'),
     (MyModel(), 'campaign_machine_with_values', 99),
 ])
-def test_state_machine_with_a_invalid_start_value(model, machine_name, start_value):
-    machine_cls = pytest.getfixturevalue(machine_name)
+def test_state_machine_with_a_invalid_start_value(request, model, machine_name, start_value):
+    machine_cls = request.getfixturevalue(machine_name)
     with pytest.raises(ValueError):
         machine_cls(model, start_value=start_value)
 

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -6,6 +6,7 @@ from statemachine import StateMachine, State
 
 
 class MyModel(object):
+    "A class that can be used to hold arbitrary key/value pairs as attributes."
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -27,6 +28,7 @@ def test_machine_should_be_at_start_state(campaign_machine):
 
 def test_machine_should_only_allow_only_one_initial_state():
     class CampaignMachine(StateMachine):
+        "A workflow machine"
         draft = State('Draft', initial=True)
         producing = State('Being produced')
         closed = State('Closed', initial=True)  # Should raise an Exception when instantiated
@@ -284,6 +286,7 @@ def test_state_machine_with_a_invalid_start_value(request, model, machine_name, 
 
 def test_should_not_create_instance_of_machine_without_states():
     class EmptyMachine(StateMachine):
+        "An empty machine"
         pass
 
     with pytest.raises(ValueError):
@@ -292,6 +295,7 @@ def test_should_not_create_instance_of_machine_without_states():
 
 def test_should_not_create_instance_of_machine_without_transitions():
     class NoTransitionsMachine(StateMachine):
+        "A machine without transitions"
         initial = State('initial')
 
     with pytest.raises(ValueError):

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -294,3 +294,15 @@ def test_should_not_create_instance_of_machine_without_transitions():
 
     with pytest.raises(ValueError):
         NoTransitionsMachine()
+
+
+def test_transition_should_accept_decorator_syntax(traffic_light_machine):
+    machine = traffic_light_machine()
+    assert machine.current_state == machine.green
+
+
+def test_transition_as_decorator_should_call_method_before_activating_state(traffic_light_machine):
+    machine = traffic_light_machine()
+    assert machine.current_state == machine.green
+    assert machine.slowdown(1, 2, number=3, text='x') == ((1, 2), {'number': 3, 'text': 'x'})
+    assert machine.current_state == machine.yellow

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -41,17 +41,6 @@ def test_machine_should_only_allow_only_one_initial_state():
         model = MyModel()
         CampaignMachine(model)
 
-
-def test_transition_representation(campaign_machine):
-    s = repr([t for t in campaign_machine.transitions if t.identifier == 'produce'][0])
-    print(s)
-    assert s == (
-        "Transition("
-         "State('Draft', identifier='draft', value='draft', initial=True), "
-         "(State('Being produced', identifier='producing', value='producing', initial=False),), identifier='produce')"
-    )
-
-
 def test_should_change_state(campaign_machine):
     model = MyModel()
     machine = campaign_machine(model)
@@ -300,15 +289,3 @@ def test_should_not_create_instance_of_machine_without_transitions():
 
     with pytest.raises(ValueError):
         NoTransitionsMachine()
-
-
-def test_transition_should_accept_decorator_syntax(traffic_light_machine):
-    machine = traffic_light_machine()
-    assert machine.current_state == machine.green
-
-
-def test_transition_as_decorator_should_call_method_before_activating_state(traffic_light_machine):
-    machine = traffic_light_machine()
-    assert machine.current_state == machine.green
-    assert machine.slowdown(1, 2, number=3, text='x') == ((1, 2), {'number': 3, 'text': 'x'})
-    assert machine.current_state == machine.yellow

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -1,0 +1,37 @@
+# coding: utf-8
+from __future__ import absolute_import, unicode_literals
+
+
+import pytest
+
+from statemachine import Transition, State
+
+
+def test_transition_representation(campaign_machine):
+    s = repr([t for t in campaign_machine.transitions if t.identifier == 'produce'][0])
+    print(s)
+    assert s == (
+        "Transition("
+         "State('Draft', identifier='draft', value='draft', initial=True), "
+         "(State('Being produced', identifier='producing', value='producing', initial=False),), identifier='produce')"
+    )
+
+
+def test_transition_should_accept_decorator_syntax(traffic_light_machine):
+    machine = traffic_light_machine()
+    assert machine.current_state == machine.green
+
+
+def test_transition_as_decorator_should_call_method_before_activating_state(traffic_light_machine):
+    machine = traffic_light_machine()
+    assert machine.current_state == machine.green
+    assert machine.slowdown(1, 2, number=3, text='x') == ((1, 2), {'number': 3, 'text': 'x'})
+    assert machine.current_state == machine.yellow
+
+
+def test_transition_call_can_only_be_used_as_decorator():
+    source, dest = State('Source'), State('Destination')
+    transition = Transition(source, dest)
+
+    with pytest.raises(ValueError):
+        transition('not a callable')


### PR DESCRIPTION
This PR aims to add two main features:

- [x] Transition from a source state to multiple destination states (multiple destination).
- [x] Transition as a decorator to specify an `on_execute` callback to be fired before the transition occours. 
- [x] In the case of multiple destination, the `on_execute` callback must return the desired state.

The syntax:

``` python
from datetime import datetime
from statemachine import StateMachine, State


class ApprovalMachine(StateMachine):
    requested = State('Requested', initial=True)
    accepted = State('Accepted')
    rejected = State('Rejected')
    completed = State('Completed')

    @requested.to(accepted, rejected)
    def validate(self, *args, **kwargs):
        if self.model.is_ok():
            self.model.accepted_at = datetime.now()
            return self.model, self.accepted
        else:
            self.model.rejected_at = datetime.now()
            return self.model, self.rejected

    @accepted.to(completed)
    def complete(self):
        self.model.completed_at = datetime.now()

    @requested.to(requested)
    def update(self, **kwargs):
        for k, v in kwargs.items():
            setattr(self.model, k, v)
        return self.model

    @rejected.to(requested)
    def retry(self):
        self.model.rejected_at = None
        return self.model
```

That can be tested with:

``` python
    model = mock.MagicMock(
        state='requested',
        accepted_at=None,
        rejected_at=None,
        completed_at=None,
    )
    machine = ApprovalMachine(model)

    model.is_ok.return_value = False

    # when
    assert machine.validate() == model

    # then
    assert model.rejected_at == current_time
    assert machine.is_rejected

    # given
    model.is_ok.return_value = True

    # when
    assert machine.retry() == model

    # then
    assert model.rejected_at is None
    assert machine.is_requested

    # when
    assert machine.validate() == model

    # then
    assert model.accepted_at == current_time
    assert machine.is_accepted
```