### PR TITLE
Registry auto discovering statemachine modules if in a Django project

### DIFF
--- a/statemachine/registry.py
+++ b/statemachine/registry.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 _REGISTRY = {}
+_initialized = False
 
 
 def register(cls):
@@ -9,4 +10,37 @@ def register(cls):
 
 
 def get_machine_cls(name):
+    init_registry()
     return _REGISTRY[name]
+
+
+def init_registry():
+    global _initialized
+    if not _initialized:
+        load_modules(['statemachine', 'statemachines'])
+        _initialized = True
+
+
+def load_modules(modules=None):
+    try:
+        import django  # noqa
+    except ImportError:
+        # Not a django project
+        return
+    try:  # pragma: no cover
+        from django.utils.module_loading import autodiscover_modules
+    except ImportError:  # pragma: no cover
+        # Django 1.6 compat to provide `autodiscover_modules`
+        def autodiscover_modules(module_name):
+            from django.conf import settings
+            from django.utils.importlib import import_module
+
+            for app in settings.INSTALLED_APPS:
+                # Attempt to import the app's `module_name`.
+                try:
+                    import_module('{app}.{module}'.format(app=app, module=module_name))
+                except Exception:
+                    pass
+
+        for module in modules:
+            autodiscover_modules(module)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,17 @@
+# coding: utf-8
+from __future__ import absolute_import, unicode_literals
+
+
+def test_should_register_a_state_machine():
+    from statemachine import StateMachine, State, registry
+
+    class CampaignMachine(StateMachine):
+        "A workflow machine"
+        draft = State('Draft', initial=True)
+        producing = State('Being produced')
+
+        add_job = draft.to(draft) | producing.to(producing)
+        produce = draft.to(producing)
+
+    assert 'CampaignMachine' in registry._REGISTRY
+    assert registry.get_machine_cls('CampaignMachine') == CampaignMachine


### PR DESCRIPTION
In order to avoid circular imports between a statemachine and a Django module, this PR leverages the use of Django `autodiscover_modules` feature. Allowing a lazy load of `statemachine` or `statemachines` modules when they are requested using the mixin/registry feature.