### PR TITLE
FEAT - Reverse transitions on StateMachine

### DIFF
--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -231,6 +231,19 @@ class State(object):
         to_method.itself = to_itself
         return to_method
 
+    @property
+    def from_(self):
+        def from_method(*states):
+            transition = ReverseTrasition(self, *states)
+            self.transitions.append(transition)
+            return transition
+
+        def from_itself():
+            return from_method(self)
+
+        from_method.itself = from_itself
+        return from_method
+
     def __contribute_to_class__(self, managed, identifier):
         self.managed = managed
         self.identifier = identifier

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -167,6 +167,10 @@ class ReverseTrasition(Transition):
         self.validators = options.get('validators', [])
         self.on_execute = options.get('on_execute')
 
+    def __repr__(self):
+        return "{}({!r}, {!r}, identifier={!r})".format(
+            type(self).__name__, self.destination, self.sources, self.identifier)
+
     def _can_run(self, machine):
         if machine.current_state in self.sources:
             return self

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -159,6 +159,22 @@ class Transition(object):
         return result, destination
 
 
+class ReverseTrasition(Transition):
+    def __init__(self, *states, **options):
+        self.destination = states[0]
+        self.sources = states[1:]
+        self.identifier = options.get('identifier')
+        self.validators = options.get('validators', [])
+        self.on_execute = options.get('on_execute')
+
+    def _can_run(self, machine):
+        if machine.current_state in self.sources:
+            return self
+
+    def _get_destination(self, result):
+        return result, self.destination
+
+
 class CombinedTransition(Transition):
 
     @property
@@ -328,7 +344,6 @@ class BaseStateMachine(object):
 
         if bounded_on_event and on_event and bounded_on_event != on_event:
             raise MultipleTransitionCallbacksFound(transition)
-
         result = None
         if callable(bounded_on_event):
             result = bounded_on_event(*args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@
 import pytest
 from datetime import datetime
 
+from statemachine import StateMachine, State
+
 
 @pytest.fixture
 def current_time():
@@ -45,32 +47,60 @@ def campaign_machine_with_values():
     return CampaignMachineWithKeys
 
 
+class BaseTrafficLightMachine(StateMachine):
+    "A traffic light machine"
+    green = State('Green', initial=True)
+    yellow = State('Yellow')
+    red = State('Red')
+
+    cycle = green.to(yellow) | yellow.to(red) | red.to(green)
+
+    @green.to(yellow)
+    def slowdown(self, *args, **kwargs):
+        return args, kwargs
+
+    @yellow.to(red)
+    def stop(self, *args, **kwargs):
+        return args, kwargs
+
+    @red.to(green)
+    def go(self, *args, **kwargs):
+        return args, kwargs
+
+    def on_cicle(self, *args, **kwargs):
+        return args, kwargs
+
+
 @pytest.fixture
 def traffic_light_machine():
-    from statemachine import StateMachine, State
 
-    class TrafficLightMachine(StateMachine):
+    return BaseTrafficLightMachine
+
+
+@pytest.fixture
+def reverse_traffic_light_machine():
+
+    class TrafficLightMachine(BaseTrafficLightMachine):
         "A traffic light machine"
         green = State('Green', initial=True)
         yellow = State('Yellow')
         red = State('Red')
 
-        cycle = green.to(yellow) | yellow.to(red) | red.to(green)
+        cycle = green.from_(red) | yellow.from_(green) | red.from_(yellow) | red.from_.itself()
 
-        @green.to(yellow)
-        def slowdown(self, *args, **kwargs):
-            return args, kwargs
+    return TrafficLightMachine
 
-        @yellow.to(red)
-        def stop(self, *args, **kwargs):
-            return args, kwargs
 
-        @red.to(green)
-        def go(self, *args, **kwargs):
-            return args, kwargs
+@pytest.fixture
+def mixed_traffic_light_machine():
 
-        def on_cicle(self, *args, **kwargs):
-            return args, kwargs
+    class TrafficLightMachine(BaseTrafficLightMachine):
+        "A traffic light machine"
+        green = State('Green', initial=True)
+        yellow = State('Yellow')
+        red = State('Red')
+
+        cycle = green.to(yellow) | yellow.to(red) | green.from_(red)
 
     return TrafficLightMachine
 

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -298,3 +298,25 @@ def test_should_not_create_instance_of_machine_without_transitions():
 
     with pytest.raises(exceptions.InvalidDefinition):
         NoTransitionsMachine()
+
+
+@pytest.mark.parametrize('machine_name', [
+    'reverse_traffic_light_machine', 'mixed_traffic_light_machine'
+])
+def test_should_cylce_using_reverse_transition(request, machine_name):
+    machine_cls = request.getfixturevalue(machine_name)
+    machine = machine_cls()
+
+    for _ in machine.states:
+        state_backup = machine.current_state
+        machine.cycle()
+        assert machine.current_state != state_backup
+
+
+def test_not_allowed_reverse_transition(reverse_traffic_light_machine):
+    machine = reverse_traffic_light_machine()
+    assert machine.initial_state.value == 'green'
+
+    with pytest.raises(exceptions.TransitionNotAllowed) as e:
+        machine.stop()
+        e.match("Can't stop when in Green")

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -19,8 +19,14 @@ def test_transition_representation(campaign_machine):
     )
 
 
-def test_transition_should_accept_decorator_syntax(traffic_light_machine):
-    machine = traffic_light_machine()
+@pytest.mark.parametrize('machine_name', [
+    'traffic_light_machine',
+    'reverse_traffic_light_machine',
+    'mixed_traffic_light_machine'
+])
+def test_transition_should_accept_decorator_syntax(request, machine_name):
+    machine_cls = request.getfixturevalue(machine_name)
+    machine = machine_cls()
     assert machine.current_state == machine.green
 
 
@@ -31,8 +37,14 @@ def test_transition_as_decorator_should_call_method_before_activating_state(traf
     assert machine.current_state == machine.yellow
 
 
-def test_cycle_transitions(traffic_light_machine):
-    machine = traffic_light_machine()
+@pytest.mark.parametrize('machine_name', [
+    'traffic_light_machine',
+    'reverse_traffic_light_machine',
+    'mixed_traffic_light_machine'
+])
+def test_cycle_transitions(request, machine_name):
+    machine_cls = request.getfixturevalue(machine_name)
+    machine = machine_cls()
     expected_states = ['green', 'yellow', 'red'] * 2
     for expected_state in expected_states:
         assert machine.current_state.identifier == expected_state


### PR DESCRIPTION
This PR aims implement a reverse transition. The feature allow us to write a way simplest code in situations which you have multiple source transitions to a unique destination, such as: 
```
class MyTransactionStateMachine(StateMachine):
    [...]
    transaction_cancel = (
            transaction_initiated.to(transaction_cancelled) |
            transaction_waiting_approval.to(transaction_cancelled) |
            transaction_in_progress.to(transaction_cancelled) |
            transaction_suspended.to(transaction_cancelled)            
    )
```

Using `from_` you are able to write a code similar to:
```
class MyTransactionStateMachine(StateMachine):
    [...]
    transaction_cancel = (
            transaction_cancelled.from_(
                transaction_initiated, 
                transaction_waiting_approval,  
                transaction_in_progress, 
                transaction_suspended
           )
    )
```