### PR TITLE
Current state equal to destination on enter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -232,7 +232,7 @@ Your model can inherited from a custom mixin to auto-instantiate a state machine
         producing = State('Being produced', value=2)
         closed = State('Closed', value=3)
 
-        add_job = draft.to(draft) | producing.to(producing)
+        add_job = draft.to.itself() | producing.to.itself()
         produce = draft.to(producing)
         deliver = producing.to(closed)
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 # deploy stuff
-pip==9.0.3
+pip==10.0.1
 bumpversion==0.5.3
 wheel==0.31.0
 cryptography==2.2.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 # deploy stuff
 pip==9.0.3
 bumpversion==0.5.3
-wheel==0.30.0
+wheel==0.31.0
 cryptography==2.2.2
 PyYAML==3.12

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-tox==2.9.1
+tox==3.0.0
 mock==2.0.0
 pytest==3.5.0
 pytest-cov==2.5.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,5 +6,5 @@ pytest-flake8==1.0.0
 pytest-watch==4.1.0
 pytest-sugar==0.9.1
 Sphinx==1.7.2
-sphinx_rtd_theme==0.2.4
+sphinx_rtd_theme==0.3.0
 restructuredtext-lint==1.1.3

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -336,6 +336,7 @@ class BaseStateMachine(object):
             result = on_event(self, *args, **kwargs)
 
         result, destination = transition._get_destination(result)
+        self.current_state = destination
 
         bounded_on_exit_state_event = getattr(self, 'on_exit_state', None)
         if callable(bounded_on_exit_state_event):
@@ -355,7 +356,6 @@ class BaseStateMachine(object):
         if callable(bounded_on_enter_specific_state_event):
             bounded_on_enter_specific_state_event()
 
-        self.current_state = destination
         return result
 
     def get_transition(self, transition_identifier):

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -295,6 +295,7 @@ class BaseStateMachine(object):
                 self.current_state_value = self.start_value
             else:
                 self.current_state_value = self.initial_state.value
+            self.previous_state = None
 
     @property
     def current_state_value(self):
@@ -336,6 +337,7 @@ class BaseStateMachine(object):
             result = on_event(self, *args, **kwargs)
 
         result, destination = transition._get_destination(result)
+        self.previous_state = self.current_state
         self.current_state = destination
 
         bounded_on_exit_state_event = getattr(self, 'on_exit_state', None)


### PR DESCRIPTION
Changed the behaviour of on_enter callbacks such that once an on_enter_abc (for state abc) callback is activated, the current state is updated to reflect the destination. This is more in line with expectations as a transition callback will have the link to the previous state but once a state has been entered and a callback called, its current state should reflect the state it is in. 