### PR TITLE
Fix registry loading modules for django 1.7+

### DIFF
--- a/statemachine/registry.py
+++ b/statemachine/registry.py
@@ -42,5 +42,5 @@ def load_modules(modules=None):
                 except Exception:
                     pass
 
-        for module in modules:
-            autodiscover_modules(module)
+    for module in modules:
+        autodiscover_modules(module)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 from __future__ import absolute_import, unicode_literals
 
+import mock
+import pytest
+
 
 def test_should_register_a_state_machine():
     from statemachine import StateMachine, State, registry
@@ -15,3 +18,31 @@ def test_should_register_a_state_machine():
 
     assert 'CampaignMachine' in registry._REGISTRY
     assert registry.get_machine_cls('CampaignMachine') == CampaignMachine
+
+
+@pytest.fixture()
+def django_module_loading():
+    import sys
+    if 'django' not in sys.modules:
+        django = mock.MagicMock()
+        module_loading = mock.MagicMock()
+        sys.modules['django'] = django
+        sys.modules['django.utils.module_loading'] = module_loading
+        yield module_loading
+        del sys.modules['django']
+        del sys.modules['django.utils.module_loading']
+
+
+def test_load_modules_should_call_autodiscover_modules(django_module_loading):
+    from statemachine.registry import load_modules
+
+    # given
+    modules = ['a', 'c', 'statemachine', 'statemachines']
+
+    # when
+    load_modules(modules)
+
+    # then
+    django_module_loading.autodiscover_modules.assert_has_calls(
+        mock.call(m) for m in modules
+    )


### PR DESCRIPTION
Fix a bug when using mixin with the Django registry not loading modules on Django1.7+.