### PR TITLE
fix(setup) fix install on Dockerfile without explicit locale closes #166

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
+import io
 from setuptools import setup
 
-with open('README.rst') as readme_file:
+with io.open('README.rst', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
+with io.open('HISTORY.rst', encoding='utf-8') as history_file:
     history = history_file.read()
 
 long_description = readme + '\n\n' + history


### PR DESCRIPTION
Closes #166 with explicit encoding of `utf-8` when reading README and HISTORY files due to non-ascii chars on examples.

To reproduce, try to build a docker image with: 

``` Dockerfile
FROM ubuntu:16.04


RUN apt-get update \
    && apt-get install -y python3 python3-pip

COPY ./setup.py ./setup.cfg ./README.rst ./HISTORY.rst /statemachine/
COPY ./docs /statemachine/docs
COPY ./tests/ /statemachine/tests
COPY ./statemachine /statemachine/statemachine
WORKDIR /statemachine

RUN pip3 install -e .
```