### PR TITLE
Add support for reverse transtitions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,13 +4,18 @@ History
 1.0.0 (not released yet)
 ------------------------
 
-* Drop official support for Python 3.4 (removing from test matrix, code may still work).
 * Add support for Python 3.7 and 3.8 (adding to test matrix).
 * Update development requirements.
 * State machine names should now be fully qualified for mixins, simple names are deprecated and
   will no longer be supported on a future version.
 * Development: Adding mypy linter.
-* Add support for State machine inheritance.
+* Add support for State machine inheritance. Thanks @rschrader.
+* Add support for reverse transitions: ``transition = state_a.from_(state_b)``.
+  Thanks @romulorosa.
+
+Breaking changes:
+
+* Drop official support for Python 3.4 (removing from test matrix, code may still work).
 
 
 0.7.1 (2019-01-18)

--- a/README.rst
+++ b/README.rst
@@ -231,10 +231,12 @@ Your model can inherited from a custom mixin to auto-instantiate a state machine
         draft = State('Draft', initial=True, value=1)
         producing = State('Being produced', value=2)
         closed = State('Closed', value=3)
+        cancelled = State('Cancelled', value=4)
 
         add_job = draft.to.itself() | producing.to.itself()
         produce = draft.to(producing)
         deliver = producing.to(closed)
+        cancel = cancelled.from_(draft, producing)
 
 
     class MyModel(MachineMixin):
@@ -253,3 +255,6 @@ Your model can inherited from a custom mixin to auto-instantiate a state machine
     assert isinstance(model.statemachine, campaign_machine)
     assert model.state == 'draft'
     assert model.statemachine.current_state == model.statemachine.draft
+
+    model.statemachine.cancel()
+    assert model.state == 'cancelled'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,10 +69,26 @@ def traffic_light_machine():
         def go(self, *args, **kwargs):
             return args, kwargs
 
-        def on_cicle(self, *args, **kwargs):
+        def on_cycle(self, *args, **kwargs):
             return args, kwargs
 
     return TrafficLightMachine
+
+
+@pytest.fixture
+def reverse_traffic_light_machine():
+    from statemachine import StateMachine, State
+
+    class ReverseTrafficLightMachine(StateMachine):
+        "A traffic light machine"
+        green = State('Green', initial=True)
+        yellow = State('Yellow')
+        red = State('Red')
+
+        stop = red.from_(yellow, green, red)
+        cycle = green.from_(red) | yellow.from_(green) | red.from_(yellow) | red.from_.itself()
+
+    return ReverseTrafficLightMachine
 
 
 @pytest.fixture

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -31,8 +31,13 @@ def test_transition_as_decorator_should_call_method_before_activating_state(traf
     assert machine.current_state == machine.yellow
 
 
-def test_cycle_transitions(traffic_light_machine):
-    machine = traffic_light_machine()
+@pytest.mark.parametrize('machine_name', [
+    'traffic_light_machine',
+    'reverse_traffic_light_machine',
+])
+def test_cycle_transitions(request, machine_name):
+    machine_class = request.getfixturevalue(machine_name)
+    machine = machine_class()
     expected_states = ['green', 'yellow', 'red'] * 2
     for expected_state in expected_states:
         assert machine.current_state.identifier == expected_state
@@ -116,3 +121,19 @@ def test_transitions_to_the_same_estate_as_itself():
     machine.update()
 
     assert machine.is_draft
+
+
+class TestReverseTransition(object):
+
+    @pytest.mark.parametrize('initial_state', [
+        'green',
+        'yellow',
+        'red',
+    ])
+    def test_reverse_transition(self, reverse_traffic_light_machine, initial_state):
+        machine = reverse_traffic_light_machine(start_value=initial_state)
+        assert machine.current_state.identifier == initial_state
+
+        machine.stop()
+
+        assert machine.is_red


### PR DESCRIPTION
Original idea from by @romulorosa (Closes #84).

This PR implements a reverse transition. The feature allow us to write a simpler code in situations which you have multiple source transitions to a unique destination, such as: 

``` python
class MyTransactionStateMachine(StateMachine):
    [...]
    cancel = (
        initiated.to(cancelled) |
        waiting_approval.to(cancelled) |
        in_progress.to(cancelled) |
        suspended.to(cancelled)            
    )
```

Using `from_` you are able to write a code similar to:

``` python
class MyTransactionStateMachine(StateMachine):
    [...]
    cancel = cancelled.from_(
        initiated, 
        waiting_approval,  
        in_progress, 
        suspended
    )

```