### PR TITLE
Fix current state equal to destination on enter events.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ History
 * Add support for State machine inheritance. Thanks @rschrader.
 * Add support for reverse transitions: ``transition = state_a.from_(state_b)``.
   Thanks @romulorosa.
+* Fix current state equal to destination on enter events. Thanks @robnils and @joshuacc1.
 
 Breaking changes:
 

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -419,21 +419,22 @@ class BaseStateMachine(object):
         if callable(bounded_on_exit_state_event):
             bounded_on_exit_state_event(self.current_state)
 
-        bounded_on_enter_state_event = getattr(self, 'on_enter_state', None)
-        if callable(bounded_on_enter_state_event):
-            bounded_on_enter_state_event(destination)
-
         bounded_on_exit_specific_state_event = getattr(
             self, 'on_exit_{}'.format(self.current_state.identifier), None)
         if callable(bounded_on_exit_specific_state_event):
             bounded_on_exit_specific_state_event()
+
+        self.current_state = destination
+
+        bounded_on_enter_state_event = getattr(self, 'on_enter_state', None)
+        if callable(bounded_on_enter_state_event):
+            bounded_on_enter_state_event(destination)
 
         bounded_on_enter_specific_state_event = getattr(
             self, 'on_enter_{}'.format(destination.identifier), None)
         if callable(bounded_on_enter_specific_state_event):
             bounded_on_enter_specific_state_event()
 
-        self.current_state = destination
         return result
 
     def get_transition(self, transition_identifier):

--- a/tests/test_state_callbacks.py
+++ b/tests/test_state_callbacks.py
@@ -29,22 +29,22 @@ def traffic_light_machine(event_mock):
             event_mock.on_exit_state(state)
 
         def on_enter_green(self):
-            event_mock.on_enter_green()
+            event_mock.on_enter_green(self)
 
         def on_exit_green(self):
-            event_mock.on_exit_green()
+            event_mock.on_exit_green(self)
 
         def on_enter_yellow(self):
-            event_mock.on_enter_yellow()
+            event_mock.on_enter_yellow(self)
 
         def on_exit_yellow(self):
-            event_mock.on_exit_yellow()
+            event_mock.on_exit_yellow(self)
 
         def on_enter_red(self):
-            event_mock.on_enter_red()
+            event_mock.on_enter_red(self)
 
         def on_exit_red(self):
-            event_mock.on_exit_red()
+            event_mock.on_exit_red(self)
 
     return TrafficLightMachineStateEvents
 
@@ -64,9 +64,37 @@ class TestStateCallbacks(object):
     def test_should_call_on_enter_of_specific_state(self, event_mock, traffic_light_machine):
         machine = traffic_light_machine()
         machine.cycle()
-        event_mock.on_enter_yellow.assert_called_once_with()
+        event_mock.on_enter_yellow.assert_called_once_with(machine)
 
     def test_should_call_on_exit_of_specific_state(self, event_mock, traffic_light_machine):
         machine = traffic_light_machine()
         machine.cycle()
-        event_mock.on_exit_green.assert_called_once_with()
+        event_mock.on_exit_green.assert_called_once_with(machine)
+
+    def test_should_be_on_the_previous_state_when_exiting(self, event_mock, traffic_light_machine):
+        machine = traffic_light_machine()
+
+        def assert_is_green_from_state(s):
+            assert s.value == 'green'
+
+        def assert_is_green(m):
+            assert m.is_green
+
+        event_mock.on_exit_state.side_effect = assert_is_green_from_state
+        event_mock.on_exit_green.side_effect = assert_is_green
+
+        machine.cycle()
+
+    def test_should_be_on_the_next_state_when_entering(self, event_mock, traffic_light_machine):
+        machine = traffic_light_machine()
+
+        def assert_is_yellow_from_state(s):
+            assert s.value == 'yellow'
+
+        def assert_is_yellow(m):
+            assert m.is_yellow
+
+        event_mock.on_enter_state.side_effect = assert_is_yellow_from_state
+        event_mock.on_enter_yellow.side_effect = assert_is_yellow
+
+        machine.cycle()


### PR DESCRIPTION
Closes #190 and #131.