### PR TITLE
Bugfix/update travis ci badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Python State Machine
 .. image:: https://img.shields.io/pypi/v/python-statemachine.svg
         :target: https://pypi.python.org/pypi/python-statemachine
 
-.. image:: https://travis-ci.org/fgmacedo/python-statemachine.svg
+.. image:: https://travis-ci.org/fgmacedo/python-statemachine.svg?branch=develop
         :target: https://travis-ci.org/fgmacedo/python-statemachine
         :alt: Build status
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
+flake8==3.7.9
 mock==3.0.5
 pytest==4.6.5  # latest 2.7 support
 pytest-cov==2.8.1


### PR DESCRIPTION
@fgmacedo thanks for building this! I'm eager to try it out and happy to see you're still supporting Python 2.7 for the time being as I'm still using that for work.

This PR addresses #248 and also pins flake8 to v3.7.9 per https://github.com/tholo/pytest-flake8/issues/66#issuecomment-637474943