### PR TITLE
fix state value misjudged when state value is an "boolean False value"

### DIFF
--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -210,7 +210,7 @@ class State(object):
 
     def _set_identifier(self, identifier):
         self.identifier = identifier
-        if not self.value:
+        if self.value is None:
             self.value = identifier
 
     def _to_(self, *states):

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -342,3 +342,18 @@ def test_should_not_create_big_disconnected_machine():
         assert 'Magenta' in e.message
         assert 'Blue' in e.message
         assert 'Cyan' not in e.message
+
+
+def test_state_value_is_correct():
+    STATE_NEW = 0
+    STATE_DRAFT = 1
+
+    class ValueTestModel(StateMachine):
+        new = State(STATE_NEW, value=STATE_NEW, initial=True)
+        draft = State(STATE_DRAFT, value=STATE_DRAFT)
+
+        write = new.to(draft)
+
+    model = ValueTestModel()
+    assert model.new.value == STATE_NEW
+    assert model.draft.value == STATE_DRAFT


### PR DESCRIPTION
fix state value misjudged when state value is an "boolean False value" rather than None