### PR TITLE
Generate state machine diagram (based on #241)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -245,3 +245,19 @@ Your model can inherited from a custom mixin to auto-instantiate a state machine
 >>> model.statemachine.cancel()
 >>> assert model.state == 4
 >>> assert model.statemachine.current_state == model.statemachine.cancelled
+
+Diagrams
+------
+
+There is possibility to generate basic state diagrams in
+`DOT <https://en.wikipedia.org/wiki/DOT_(graph_description_language)>`_ format as string.
+
+>>> from statemachine.diagram import dot_data_from_machine
+>>> dot_data = dot_data_from_machine(TrafficLightMachine)
+
+To visualize generated diagrams you can use one of available tools:
+`pydot <https://pypi.org/project/pydot/>`_, `graphviz <https://pypi.org/project/graphviz/>`_, ...::
+
+    import pydot
+    graph = pydot.graph_from_dot_data(dot_data)[0]
+    graph.write_png("output.png")

--- a/statemachine/diagram.py
+++ b/statemachine/diagram.py
@@ -1,0 +1,36 @@
+# coding: utf-8
+from statemachine import StateMachine, Transition, State
+from typing import Type
+
+
+def _process_transition(transition):
+    # type: (Transition) -> str
+
+    result = ''
+    for destination in transition.destinations:
+        result += '{}->{}[label="{}"];'.format(
+            transition.source.identifier, destination.identifier, transition.identifier
+        )
+
+    return result
+
+
+def _process_state(state):
+    # type: (State) -> str
+
+    if state.initial:
+        return '{}[color=blue];'.format(state.identifier)
+    else:
+        return '{};'.format(state.identifier)
+
+
+def dot_data_from_machine(machine_class_type):
+    # type: (Type[StateMachine]) -> str
+    result = 'labelloc="t"; label="{}";'.format(machine_class_type.__name__)
+
+    for state in machine_class_type.states:
+        result += _process_state(state)
+        for transition in state.transitions:
+            result += _process_transition(transition)
+
+    return 'digraph {} {{{}}}'.format(machine_class_type.__name__, result)

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -1,0 +1,46 @@
+from statemachine.diagram import dot_data_from_machine
+from statemachine import StateMachine
+
+
+def visualize_diagram_in_png(data):
+    import pydot
+
+    graph = pydot.graph_from_dot_data(data)[0]
+    graph.write_png('output.png')
+
+
+def test_diagram_from_dummy_machine():
+    class DummyMachine(StateMachine):
+        pass
+
+    expected = 'digraph DummyMachine{ labelloc="t"; label="DummyMachine";}'
+
+    data = dot_data_from_machine(DummyMachine)
+    assert set(data.replace(' ', '').split(';')) == set(expected.replace(' ', '').split(';'))
+    # visualize_diagram_in_png(data)
+
+
+def test_diagram_for_campaign_machine(campaign_machine):
+    expected = (
+        'digraph CampaignMachine { labelloc="t"; label="CampaignMachine"; '
+        'closed;draft [color=blue];producing; draft -> draft [label="add_job"];'
+        'draft -> producing [label="produce"];producing -> producing [label="add_job"];'
+        'producing -> closed [label="deliver"]; }'
+    )
+
+    data = dot_data_from_machine(campaign_machine)
+    assert set(data.replace(' ', '').split(';')) == set(expected.replace(' ', '').split(';'))
+    # visualize_diagram_in_png(data)
+
+
+def test_diagram_for_traffic_light_machine(traffic_light_machine):
+    expected = (
+        'digraph TrafficLightMachine { labelloc="t"; label="TrafficLightMachine"; '
+        'green [color=blue];red;yellow; green -> yellow [label="cycle"];'
+        'green -> yellow [label="slowdown"];red -> green [label="cycle"];'
+        'red -> green [label="go"];yellow -> red [label="cycle"];yellow -> red [label="stop"]; }'
+    )
+
+    data = dot_data_from_machine(traffic_light_machine)
+    assert set(data.replace(' ', '').split(';')) == set(expected.replace(' ', '').split(';'))
+    # visualize_diagram_in_png(data)


### PR DESCRIPTION
PR based on #241 

Add possibility to generate diagrams from state machine classes. Diagram is represented as string in DOT format and can be visualized with available 3rdparty tools.
