### PR TITLE
Feat: Add final states

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -263,19 +263,28 @@ Transitions from these states are not allowed and will raise exception.
 ...     deliver = producing.to(closed)
 
 
->>> from statemachine.exceptions import TransitionNotAllowed
->>> model = MyModel(state=3)
->>> machine = CampaignMachine(model)
+>>> from statemachine.exceptions import InvalidDefinition
 >>> try:
-...     machine.run("add_job")
-... except TransitionNotAllowed as err:
+...     machine = CampaignMachine(model)
+... except InvalidDefinition as err:
 ...     print(err)
-Can't add_job when in Closed.
-
+Final state does not should have defined transitions starting from that state
 
 
 You can retrieve all final states.
 
+>>> class CampaignMachine(StateMachine):
+...     "A workflow machine"
+...     draft = State('Draft', initial=True, value=1)
+...     producing = State('Being produced', value=2)
+...     closed = State('Closed', final=True, value=3)
+...
+...     add_job = draft.to.itself() | producing.to.itself()
+...     produce = draft.to(producing)
+...     deliver = producing.to(closed)
+
+>>> model = MyModel(state=3)
+>>> machine = CampaignMachine(model)
 >>> machine.final_states
 [State('Closed', identifier='closed', value=3, initial=False, final=True)]
 

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ You can now create an instance:
 And inspect about the current state:
 
 >>> traffic_light.current_state
-State('Green', identifier='green', value='green', initial=True)
+State('Green', identifier='green', value='green', initial=True, final=False)
 >>> traffic_light.current_state == TrafficLightMachine.green == traffic_light.green
 True
 
@@ -87,7 +87,7 @@ Call a transition:
 And check for the current status:
 
 >>> traffic_light.current_state
-State('Yellow', identifier='yellow', value='yellow', initial=False)
+State('Yellow', identifier='yellow', value='yellow', initial=False, final=False)
 >>> traffic_light.is_yellow
 True
 
@@ -245,3 +245,37 @@ Your model can inherited from a custom mixin to auto-instantiate a state machine
 >>> model.statemachine.cancel()
 >>> assert model.state == 4
 >>> assert model.statemachine.current_state == model.statemachine.cancelled
+
+Final States
+------
+
+You can explicitly set final states.
+Transitions from these states are not allowed and will raise exception.
+
+>>> class CampaignMachine(StateMachine):
+...     "A workflow machine"
+...     draft = State('Draft', initial=True, value=1)
+...     producing = State('Being produced', value=2)
+...     closed = State('Closed', final=True, value=3)
+...
+...     add_job = draft.to.itself() | producing.to.itself() | closed.to(producing)
+...     produce = draft.to(producing)
+...     deliver = producing.to(closed)
+
+
+>>> from statemachine.exceptions import TransitionNotAllowed
+>>> model = MyModel(state=3)
+>>> machine = CampaignMachine(model)
+>>> try:
+...     machine.run("add_job")
+... except TransitionNotAllowed as err:
+...     print(err)
+Can't add_job when in Closed.
+
+
+
+You can retrieve all final states.
+
+>>> machine.final_states
+[State('Closed', identifier='closed', value=3, initial=False, final=True)]
+

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -205,8 +205,8 @@ class State(object):
         self._final = final
 
     def __repr__(self):
-        return "{}({!r}, identifier={!r}, value={!r}, initial={!r})".format(
-            type(self).__name__, self.name, self.identifier, self.value, self.initial
+        return "{}({!r}, identifier={!r}, value={!r}, initial={!r}, final={!r})".format(
+            type(self).__name__, self.name, self.identifier, self.value, self.initial, self.final
         )
 
     def _set_identifier(self, identifier):

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -99,7 +99,7 @@ class Transition(object):
         self.identifier = identifier
 
     def _can_run(self, machine):
-        if machine.current_state == self.source:
+        if machine.current_state == self.source and not self.source.final:
             return self
 
     def _verify_can_run(self, machine):
@@ -195,13 +195,14 @@ class CombinedTransition(Transition):
 
 class State(object):
 
-    def __init__(self, name, value=None, initial=False):
+    def __init__(self, name, value=None, initial=False, final=False):
         # type: (Text, Optional[V], bool) -> None
         self.name = name
         self.value = value
         self._initial = initial
         self.identifier = None  # type: Optional[Text]
         self.transitions = []  # type: List[Transition]
+        self._final = final
 
     def __repr__(self):
         return "{}({!r}, identifier={!r}, value={!r}, initial={!r})".format(
@@ -250,6 +251,10 @@ class State(object):
     @property
     def initial(self):
         return self._initial
+
+    @property
+    def final(self):
+        return self._final
 
 
 def check_state_factory(state):
@@ -369,6 +374,10 @@ class BaseStateMachine(object):
                 self.current_state_value = self.start_value
             else:
                 self.current_state_value = self.initial_state.value
+
+    @property
+    def final_states(self):
+        return [state for state in self.states if state.final]
 
     @property
     def current_state_value(self):

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -99,7 +99,7 @@ class Transition(object):
         self.identifier = identifier
 
     def _can_run(self, machine):
-        if machine.current_state == self.source and not self.source.final:
+        if machine.current_state == self.source:
             return self
 
     def _verify_can_run(self, machine):
@@ -368,6 +368,15 @@ class BaseStateMachine(object):
             raise InvalidDefinition(_('There are unreachable states. '
                                     'The statemachine graph should have a single component. '
                                       'Disconnected states: [{}]'.format(disconnected_states)))
+
+        finals = self.final_states
+        final_state_with_invalid_transitions = [
+            state for state in finals if state.transitions
+        ]
+
+        if final_state_with_invalid_transitions:
+            raise InvalidDefinition(_('Final state does not should have defined '
+                                      'transitions starting from that state'))
 
         if self.current_state_value is None:
             if self.start_value:

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -369,9 +369,8 @@ class BaseStateMachine(object):
                                     'The statemachine graph should have a single component. '
                                       'Disconnected states: [{}]'.format(disconnected_states)))
 
-        finals = self.final_states
         final_state_with_invalid_transitions = [
-            state for state in finals if state.transitions
+            state for state in self.final_states if state.transitions
         ]
 
         if final_state_with_invalid_transitions:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,24 @@ def campaign_machine_with_invalid_final_state_transition():
 
 
 @pytest.fixture
+def campaign_machine_with_final_state():
+    "Define a new class for each test"
+    from statemachine import State, StateMachine
+
+    class CampaignMachine(StateMachine):
+        "A workflow machine"
+        draft = State('Draft', initial=True)
+        producing = State('Being produced')
+        closed = State('Closed', final=True)
+
+        add_job = draft.to(draft) | producing.to(producing)
+        produce = draft.to(producing)
+        deliver = producing.to(closed)
+
+    return CampaignMachine
+
+
+@pytest.fixture
 def campaign_machine_with_values():
     "Define a new class for each test"
     from statemachine import State, StateMachine

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,24 @@ def campaign_machine():
 
 
 @pytest.fixture
+def campaign_machine_with_invalid_final_state_transition():
+    "Define a new class for each test"
+    from statemachine import State, StateMachine
+
+    class CampaignMachine(StateMachine):
+        "A workflow machine"
+        draft = State('Draft', initial=True)
+        producing = State('Being produced')
+        closed = State('Closed', final=True)
+
+        add_job = draft.to(draft) | producing.to(producing) | closed.to(draft)
+        produce = draft.to(producing)
+        deliver = producing.to(closed)
+
+    return CampaignMachine
+
+
+@pytest.fixture
 def campaign_machine_with_values():
     "Define a new class for each test"
     from statemachine import State, StateMachine

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -120,6 +120,19 @@ def test_call_to_transition_that_is_not_in_the_current_state_should_raise_except
         machine.run(transition)
 
 
+@pytest.mark.parametrize('current_state, transition', [('closed', 'add_job')])
+def test_call_to_transition_from_final_state_should_raise_exception(
+        campaign_machine_with_invalid_final_state_transition, current_state, transition):
+
+    model = MyModel(state=current_state)
+    machine = campaign_machine_with_invalid_final_state_transition(model)
+
+    assert machine.current_state.value == current_state
+
+    with pytest.raises(exceptions.TransitionNotAllowed):
+        machine.run(transition)
+
+
 def test_machine_should_list_allowed_transitions_in_the_current_state(campaign_machine):
 
     model = MyModel()
@@ -357,3 +370,11 @@ def test_state_value_is_correct():
     model = ValueTestModel()
     assert model.new.value == STATE_NEW
     assert model.draft.value == STATE_DRAFT
+
+
+def test_final_states(campaign_machine_with_invalid_final_state_transition):
+    model = MyModel()
+    machine = campaign_machine_with_invalid_final_state_transition(model)
+    final_states = machine.final_states
+    assert len(final_states) == 1
+    assert final_states[0].name == "Closed"

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -50,6 +50,14 @@ def test_machine_should_only_allow_only_one_initial_state():
         CampaignMachine(model)
 
 
+def test_machine_should_not_allow_transitions_from_final_state(
+    campaign_machine_with_invalid_final_state_transition
+):
+    with pytest.raises(exceptions.InvalidDefinition):
+        model = MyModel()
+        campaign_machine_with_invalid_final_state_transition(model)
+
+
 def test_should_change_state(campaign_machine):
     model = MyModel()
     machine = campaign_machine(model)
@@ -113,19 +121,6 @@ def test_call_to_transition_that_is_not_in_the_current_state_should_raise_except
 
     model = MyModel(state=current_state)
     machine = campaign_machine(model)
-
-    assert machine.current_state.value == current_state
-
-    with pytest.raises(exceptions.TransitionNotAllowed):
-        machine.run(transition)
-
-
-@pytest.mark.parametrize('current_state, transition', [('closed', 'add_job')])
-def test_call_to_transition_from_final_state_should_raise_exception(
-        campaign_machine_with_invalid_final_state_transition, current_state, transition):
-
-    model = MyModel(state=current_state)
-    machine = campaign_machine_with_invalid_final_state_transition(model)
 
     assert machine.current_state.value == current_state
 
@@ -372,9 +367,9 @@ def test_state_value_is_correct():
     assert model.draft.value == STATE_DRAFT
 
 
-def test_final_states(campaign_machine_with_invalid_final_state_transition):
+def test_final_states(campaign_machine_with_final_state):
     model = MyModel()
-    machine = campaign_machine_with_invalid_final_state_transition(model)
+    machine = campaign_machine_with_final_state(model)
     final_states = machine.final_states
     assert len(final_states) == 1
     assert final_states[0].name == "Closed"

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -13,9 +13,9 @@ def test_transition_representation(campaign_machine):
     print(s)
     assert s == (
         "Transition("
-        "State('Draft', identifier='draft', value='draft', initial=True), "
+        "State('Draft', identifier='draft', value='draft', initial=True, final=False), "
         "(State('Being produced', identifier='producing', value='producing', "
-        "initial=False),), identifier='produce')"
+        "initial=False, final=False),), identifier='produce')"
     )
 
 


### PR DESCRIPTION
Add a feature to explicitly define which states are final states.

This requires avoiding transitions coming from final states and also makes it possible to list all final states of an FSM.

The Java Spring-statemachine is an example of FSM implementation which allow final states definition:
https://docs.spring.io/spring-statemachine/docs/current/reference/#statemachine-config-states
```
...
	.withStates()
		.initial(States.S1)
		.end(States.SF) // Final State definition
		.states(EnumSet.allOf(States.class));
...
```

