### PR TITLE
chore: add args to bounded transitions

### DIFF
--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -19,16 +19,13 @@ from .utils import ugettext as _
 V = TypeVar('V')
 
 
-def is_callable_with(f, *args, **kwargs):
-    try:
-        inspect.signature(f).bind(*args, **kwargs)
-        return True
-    except TypeError:
-        return False
+def is_callable_with_kwargs(f):
+    # python 3 variant -> return inspect.getfullargspec(f).varkw is not None
+    return inspect.getargspec(f).keywords is not None
 
 
 def call_with_args(f, *args, **kwargs):
-    if is_callable_with(f, *args, **kwargs):
+    if is_callable_with_kwargs(f):
         f(*args, **kwargs)
     else:
         f()

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -417,23 +417,23 @@ class BaseStateMachine(object):
 
         bounded_on_exit_state_event = getattr(self, 'on_exit_state', None)
         if callable(bounded_on_exit_state_event):
-            bounded_on_exit_state_event(self.current_state)
+            bounded_on_exit_state_event(self.current_state, *args, **kwargs)
 
         bounded_on_exit_specific_state_event = getattr(
             self, 'on_exit_{}'.format(self.current_state.identifier), None)
         if callable(bounded_on_exit_specific_state_event):
-            bounded_on_exit_specific_state_event()
+            bounded_on_exit_specific_state_event(*args, **kwargs)
 
         self.current_state = destination
 
         bounded_on_enter_state_event = getattr(self, 'on_enter_state', None)
         if callable(bounded_on_enter_state_event):
-            bounded_on_enter_state_event(destination)
+            bounded_on_enter_state_event(destination, *args, **kwargs)
 
         bounded_on_enter_specific_state_event = getattr(
             self, 'on_enter_{}'.format(destination.identifier), None)
         if callable(bounded_on_enter_specific_state_event):
-            bounded_on_enter_specific_state_event()
+            bounded_on_enter_specific_state_event(*args, **kwargs)
 
         return result
 

--- a/tests/test_statemachine_bounded_transitions.py
+++ b/tests/test_statemachine_bounded_transitions.py
@@ -1,0 +1,54 @@
+# coding: utf-8
+
+import mock
+import pytest
+
+from statemachine import StateMachine, State
+
+
+class MyModel(object):
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def __repr__(self):
+        return "{}({!r})".format(type(self).__name__, self.__dict__)
+
+
+class CampaignMachine(StateMachine):
+    draft = State("Draft", initial=True)
+    producing = State("Being produced")
+    closed = State("Closed")
+
+    add_job = draft.to(draft) | producing.to(producing)
+    produce = draft.to(producing)
+    deliver = producing.to(closed)
+
+    def on_enter_producing(self, **kwargs):
+        pass
+
+    def on_exit_draft(self, **kwargs):
+        pass
+
+
+@pytest.fixture()
+def on_enter_mock():
+    with mock.patch.object(CampaignMachine, "on_enter_producing") as m:
+        yield m
+
+
+@pytest.fixture()
+def on_exit_mock():
+    with mock.patch.object(CampaignMachine, "on_exit_draft") as m:
+        yield m
+
+
+def test_run_transition_pass_arguments_to_sub_transitions(on_enter_mock, on_exit_mock):
+    model = MyModel(state="draft")
+    machine = CampaignMachine(model)
+
+    machine.run("produce", param1="value1", param2="value2")
+
+    assert model.state == "producing"
+    on_enter_mock.assert_called_with(param1="value1", param2="value2")
+    on_exit_mock.assert_called_with(param1="value1", param2="value2")

--- a/tests/test_statemachine_bounded_transitions.py
+++ b/tests/test_statemachine_bounded_transitions.py
@@ -31,8 +31,8 @@ def state_machine(event_mock):
         produce = draft.to(producing)
         deliver = producing.to(closed)
 
-        def on_enter_producing(self, **kwargs):
-            event_mock.on_enter_producing(**kwargs)
+        def on_enter_producing(self, *args, **kwargs):
+            event_mock.on_enter_producing(*args, **kwargs)
 
         def on_exit_draft(self, **kwargs):
             event_mock.on_exit_draft(**kwargs)


### PR DESCRIPTION
## About the task
Add args to the bounded transitions "on_enter_*", "on_exit_*", to add more logic on state machine transitions, that will allow us to use the same args used to make the transition on the bounded transitions as well.

## Output of tox

![image](https://user-images.githubusercontent.com/6535255/208177205-4f88176c-e707-4273-94ed-04017e55ec46.png)
