### PR TITLE
gh-actions "test-coverage" and "bump-version"

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
             python -m pip install --upgrade tox-gh-actions
-            python -m pip install -r requirements.txt
+            python -m pip install -r requirements_test.txt
     
     - name: Generate coverage report
       run: "python -m pytest --cov=./ --cov-report=xml"

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,47 @@
+name: Coverage workflow
+
+on: [push, pull_request]
+
+jobs:
+  codecov:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 3
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.9]
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python }}
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+            python -m pip install --upgrade tox-gh-actions
+            python -m pip install -r requirements.txt
+    
+    - name: Generate coverage report
+      run: "python -m pytest --cov=./ --cov-report=xml"
+    
+    - name: Run tox
+      run: "python -m tox -vv"
+    
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        directory: ./coverage/reports/
+        env_vars: OS,PYTHON
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false
+        files: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        path_to_write_report: ./coverage/codecov_report.txt
+        verbose: true


### PR DESCRIPTION
Related issue: [#291](https://github.com/fgmacedo/python-statemachine/issues/291)

Benchmarks: 
    
- [X] Codecov           : https://github.com/marketplace/actions/codecov
- [ ] Bump version : Reference needed

Considerations: 

- Codecov has plenty of benchmarks: it requires only fine-tuning and triming;
- Bump-version is a bit more sensitive due semantic versioning. @fgmacedo is needed to clarify current bump-version usage. 

A common practice is to tag on publish action. However, It requires at least some user-provided information `[patch, minor, major]`.  

