### PR TITLE
refac: Extract code to medicated modules

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length = 99
 exclude = .git/*,.tox/*,docs/*,dist/*,build/*
+ignore = E231,W503

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,8 +66,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"Python State Machine"
-copyright = u"2022, Fernando Macedo"
+project = "Python State Machine"
+copyright = "2022, Fernando Macedo"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -220,8 +220,8 @@ latex_documents = [
     (
         "index",
         "statemachine.tex",
-        u"Python State Machine Documentation",
-        u"Fernando Macedo",
+        "Python State Machine Documentation",
+        "Fernando Macedo",
         "manual",
     ),
 ]
@@ -255,8 +255,8 @@ man_pages = [
     (
         "index",
         "statemachine",
-        u"Python State Machine Documentation",
-        [u"Fernando Macedo"],
+        "Python State Machine Documentation",
+        ["Fernando Macedo"],
         1,
     )
 ]
@@ -274,8 +274,8 @@ texinfo_documents = [
     (
         "index",
         "statemachine",
-        u"Python State Machine Documentation",
-        u"Fernando Macedo",
+        "Python State Machine Documentation",
+        "Fernando Macedo",
         "statemachine",
         "One line description of project.",
         "Miscellaneous",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ setup(
     author="Fernando Macedo",
     author_email="fgmacedo@gmail.com",
     url="https://github.com/fgmacedo/python-statemachine",
-    packages=["statemachine", ],
+    packages=[
+        "statemachine",
+    ],
     package_dir={"statemachine": "statemachine"},
     include_package_data=True,
     license="MIT license",

--- a/statemachine/callable_proxy.py
+++ b/statemachine/callable_proxy.py
@@ -1,0 +1,41 @@
+class CallableInstance(object):
+    """
+    Proxy that can override params by passing in kwargs and can run a callable.
+
+    When a user wants to call a transition from the state machine, the instance
+    of the state machine is only know at the __get__ method of the transition,
+    since it's a property descriptor.
+
+    To allow concurrency, we cannot store the current instance in the
+    descriptor, as it permits only one instance to call a transition  at a
+    time.
+
+    The CallableInstance is a proxy that acts like the original object, but has
+    a __call__ method that can run a lambda function.
+
+    And you can customize/override any attr by defining **kwargs.
+    """
+
+    def __init__(self, target, func, **kwargs):
+        self.__dict__["target"] = target
+        self.__dict__["func"] = func
+        self.__dict__["kwargs"] = kwargs
+        for k, v in kwargs.items():
+            self.__dict__[k] = v
+
+    def __getattr__(self, value):
+        return getattr(self.target, value)
+
+    def __setattr__(self, key, value):
+        setattr(self.target, key, value)
+
+    def __repr__(self):
+        return "{}({}, func={!r}, **{!r})".format(
+            type(self).__name__,
+            repr(self.target),
+            self.func,
+            self.kwargs,
+        )
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)

--- a/statemachine/event.py
+++ b/statemachine/event.py
@@ -1,0 +1,118 @@
+import warnings
+from collections import OrderedDict
+
+from .callable_proxy import CallableInstance
+from .event_data import EventData
+from .exceptions import TransitionNotAllowed
+from .transition_list import TransitionList
+from .utils import ensure_iterable
+
+
+class OrderedDefaultDict(OrderedDict):  # python <= 3.5 compat layer
+    factory = TransitionList
+
+    def __missing__(self, key):
+        self[key] = value = self.factory()
+        return value
+
+
+class Event(object):
+    def __init__(self, name):
+        self.name = name
+        self._transitions = OrderedDefaultDict()
+
+    def __repr__(self):
+        return "{}({!r}, {!r})".format(
+            type(self).__name__, self.name, self._transitions
+        )
+
+    def __get__(self, machine, owner):
+        def trigger_callback(*args, **kwargs):
+            return self.trigger(machine, *args, **kwargs)
+
+        return CallableInstance(self, func=trigger_callback)
+
+    def __set__(self, instance, value):
+        "does nothing (not allow overriding)"
+
+    def add_transition(self, transition):
+        transition.trigger = self.name
+        self._transitions[transition.source].add_transitions(transition)
+
+    def add_transitions(self, transitions):
+        transitions = ensure_iterable(transitions)
+        for transition in transitions:
+            self.add_transition(transition)
+
+    @property
+    def identifier(self):
+        warnings.warn(
+            "identifier is deprecated. Use `name` instead", DeprecationWarning
+        )
+        return self.name
+
+    @property
+    def validators(self):
+        warnings.warn(
+            "`validators` is deprecated. Use `conditions` instead", DeprecationWarning
+        )
+        return list(
+            {
+                validator
+                for transition in self.transitions
+                for validator in transition.validators
+            }
+        )
+
+    @validators.setter
+    def validators(self, value):
+        warnings.warn(
+            "`validators` is deprecated. Use `conditions` instead", DeprecationWarning
+        )
+        for transition in self.transitions:
+            transition.validators = value
+
+    @property
+    def transitions(self):
+        return [
+            transition
+            for transition_list in self._transitions.values()
+            for transition in transition_list
+        ]
+
+    def _check_is_valid_source(self, state):
+        if state not in self._transitions:
+            raise TransitionNotAllowed(self, state)
+
+    def trigger(self, machine, *args, **kwargs):
+        event_data = EventData(machine, self, *args, **kwargs)
+
+        def trigger_wrapper():
+            """Wrapper that captures event_data as closure."""
+            return self._trigger(event_data)
+
+        return machine._process(trigger_wrapper)
+
+    def _trigger(self, event_data):
+        event_data.source = event_data.machine.current_state
+        event_data.state = event_data.machine.current_state
+        event_data.model = event_data.machine.model
+
+        try:
+            self._check_is_valid_source(event_data.state)
+            self._process(event_data)
+        except Exception as error:
+            event_data.error = error
+            # TODO: Log errors
+            # TODO: Allow exception handlers
+            raise
+        return event_data.result
+
+    def _process(self, event_data):
+        for transition in self._transitions[event_data.state]:
+            event_data.transition = transition
+            if transition.execute(event_data):
+                event_data.executed = True
+                break
+        else:
+            raise TransitionNotAllowed(self, event_data.state)

--- a/statemachine/event_data.py
+++ b/statemachine/event_data.py
@@ -1,0 +1,29 @@
+class EventData(object):
+    def __init__(self, machine, event, *args, **kwargs):
+        self.machine = machine
+        self.event = event
+        self.source = None
+        self.state = None
+        self.model = None
+        self.transition = None
+        self.executed = False
+
+        # runtime and error
+        self.args = args
+        self.kwargs = kwargs
+        self.error = None
+        self.result = None
+
+    def __repr__(self):
+        return "{}({!r})".format(type(self).__name__, self.__dict__)
+
+    @property
+    def extended_kwargs(self):
+        kwargs = self.kwargs.copy()
+        kwargs["event_data"] = self
+        kwargs["event"] = self.event
+        kwargs["source"] = self.source
+        kwargs["state"] = self.state
+        kwargs["model"] = self.model
+        kwargs["transition"] = self.transition
+        return kwargs

--- a/statemachine/model.py
+++ b/statemachine/model.py
@@ -1,0 +1,9 @@
+# coding: utf-8
+
+
+class Model(object):
+    def __init__(self):
+        self.state = None
+
+    def __repr__(self):
+        return "Model(state={})".format(self.state)

--- a/statemachine/registry.py
+++ b/statemachine/registry.py
@@ -9,7 +9,7 @@ def _qualname(cls):
     """
     Returns a fully qualified name of the class, to avoid name collisions.
     """
-    return u".".join([cls.__module__, cls.__name__])
+    return ".".join([cls.__module__, cls.__name__])
 
 
 def register(cls):

--- a/statemachine/state.py
+++ b/statemachine/state.py
@@ -1,0 +1,112 @@
+# coding: utf-8
+from typing import Any, Optional, Text
+
+from .callbacks import Callbacks, resolver_factory
+from .transition_list import TransitionList
+from .transition import Transition
+
+
+class State(object):
+    """
+    A state in a state machine describes a particular behaviour of the machine.
+    When we say that a machine is “in” a state, it means that the machine behaves
+    in the way that state describes.
+    """
+
+    def __init__(
+        self, name, value=None, initial=False, final=False, enter=None, exit=None
+    ):
+        # type: (Text, Optional[Any], bool, bool, Optional[Any], Optional[Any]) -> None
+        self.name = name
+        self.value = value
+        self._initial = initial
+        self.identifier = None  # type: Optional[Text]
+        self.transitions = TransitionList()
+        self._final = final
+        self.enter = Callbacks().add(enter)
+        self.exit = Callbacks().add(exit)
+
+    def setup(self, machine):
+        resolver = resolver_factory(machine, machine.model)
+        self.enter.setup(resolver)
+        self.exit.setup(resolver)
+
+        self.enter.add(
+            ["on_enter_state", "on_enter_{}".format(self.identifier)],
+            resolver,
+            suppress_errors=True,
+        )
+        self.exit.add(
+            ["on_exit_state", "on_exit_{}".format(self.identifier)],
+            resolver,
+            suppress_errors=True,
+        )
+
+    def __repr__(self):
+        return "{}({!r}, identifier={!r}, value={!r}, initial={!r}, final={!r})".format(
+            type(self).__name__,
+            self.name,
+            self.identifier,
+            self.value,
+            self.initial,
+            self.final,
+        )
+
+    def __get__(self, machine, owner):
+        return self
+
+    def __set__(self, instance, value):
+        "does nothing (not allow overriding)"
+
+    def _set_identifier(self, identifier):
+        self.identifier = identifier
+        if self.value is None:
+            self.value = identifier
+
+    def _to_(self, *states, **kwargs):
+        transitions = TransitionList(
+            Transition(self, state, **kwargs) for state in states
+        )
+        self.transitions.add_transitions(transitions)
+        return transitions
+
+    def _from_(self, *states, **kwargs):
+        transitions = TransitionList()
+        for origin in states:
+            transition = Transition(origin, self, **kwargs)
+            origin.transitions.add_transitions(transition)
+            transitions.add_transitions(transition)
+        return transitions
+
+    def _get_proxy_method_to_itself(self, method):
+        def proxy(*states, **kwargs):
+            return method(*states, **kwargs)
+
+        def proxy_to_itself(**kwargs):
+            return proxy(self, **kwargs)
+
+        proxy.itself = proxy_to_itself
+        return proxy
+
+    @property
+    def to(self):
+        """Create transitions to the given destination states.
+
+        .. code::
+
+            <origin_state>.to(*<destination_state>)
+
+        """
+        return self._get_proxy_method_to_itself(self._to_)
+
+    @property
+    def from_(self):
+        return self._get_proxy_method_to_itself(self._from_)
+
+    @property
+    def initial(self):
+        return self._initial
+
+    @property
+    def final(self):
+        return self._final

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -1,449 +1,23 @@
 # coding: utf-8
+
 import warnings
 from collections import OrderedDict
-from functools import wraps
-from weakref import ref
 
-from typing import Any, List, Dict, Optional, TypeVar, Text, Generic
+from typing import Any, List, Dict, Optional
 
 from . import registry
+from .event import Event
 from .exceptions import (
     InvalidDefinition,
     InvalidStateValue,
     InvalidTransitionIdentifier,
-    TransitionNotAllowed,
 )
-from .utils import ugettext as _, ensure_iterable
 from .graph import visit_connected_states
-from .callbacks import Callbacks, ConditionWrapper, resolver_factory, methodcaller
-
-V = TypeVar("V")
-
-
-class CallableInstance(object):
-    """
-    Proxy that can override params by passing in kwargs and can run a callable.
-
-    When a user wants to call a transition from the state machine, the instance
-    of the state machine is only know at the __get__ method of the transition,
-    since it's a property descriptor.
-
-    To allow concurrency, we cannot store the current instance in the
-    descriptor, as it permits only one instance to call a transition  at a
-    time.
-
-    The CallableInstance is a proxy that acts like the original object, but has
-    a __call__ method that can run a lambda function.
-
-    And you can customize/override any attr by defining **kwargs.
-    """
-
-    def __init__(self, target, func, **kwargs):
-        self.__dict__["target"] = target
-        self.__dict__["func"] = func
-        self.__dict__["kwargs"] = kwargs
-        for k, v in kwargs.items():
-            self.__dict__[k] = v
-
-    def __getattr__(self, value):
-        return getattr(self.target, value)
-
-    def __setattr__(self, key, value):
-        setattr(self.target, key, value)
-
-    def __repr__(self):
-        return "{}({}, func={!r}, **{!r})".format(
-            type(self).__name__, repr(self.target), self.func, self.kwargs,
-        )
-
-    def __call__(self, *args, **kwargs):
-        return self.func(*args, **kwargs)
-
-
-class Transition(object):
-    """
-    A transition holds reference to the source and destination state.
-    """
-
-    def __init__(
-        self,
-        source,
-        destination,
-        trigger=None,
-        validators=None,
-        conditions=None,
-        unless=None,
-        on_execute=None,
-        before=None,
-        after=None,
-    ):
-        self.source = source
-        self.destination = destination
-        self.trigger = trigger
-        self.validators = validators if validators is not None else []
-        self.before = Callbacks() \
-            .add("before_transition", suppress_errors=True).add(before).add(on_execute)
-        self.after = Callbacks().add(after)
-        self.conditions = (
-            Callbacks(factory=ConditionWrapper)
-            .add(conditions)
-            .add(unless, expected_value=False)
-        )
-        self.machine = None
-
-    def __repr__(self):
-        return "{}({!r}, {!r}, trigger={!r})".format(
-            type(self).__name__, self.source, self.destination, self.trigger
-        )
-
-    def _get_promisse_to_machine(self, func):
-
-        decorated = methodcaller(func)
-
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            return decorated(self.machine(), *args, **kwargs)
-
-        return wrapper
-
-    def setup(self, machine):
-        self.machine = ref(machine)
-        resolver = resolver_factory(machine, machine.model)
-        self.before.setup(resolver)
-        self.after.setup(resolver)
-        self.conditions.setup(resolver)
-
-        self.before.add(
-            [
-                "before_{}".format(self.trigger),
-                "on_{}".format(self.trigger),
-            ],
-            resolver,
-            suppress_errors=True,
-        )
-        self.after.add(
-            ["after_{}".format(self.trigger), "after_transition"],
-            resolver,
-            suppress_errors=True,
-        )
-
-    def _validate(self, *args, **kwargs):
-        for validator in self.validators:
-            validator(*args, **kwargs)
-
-    def _eval_conditions(self, event_data):
-        return all(
-            condition(*event_data.args, **event_data.extended_kwargs)
-            for condition in self.conditions
-        )
-
-    @property
-    def identifier(self):
-        warnings.warn(
-            "identifier is deprecated. Use `trigger` instead", DeprecationWarning
-        )
-        return self.trigger
-
-    def execute(self, event_data):
-        self._validate(*event_data.args, **event_data.kwargs)
-        if not self._eval_conditions(event_data):
-            return False
-
-        result = event_data.machine._activate(event_data)
-        event_data.result = result
-        return True
-
-
-class TransitionList(object):
-    def __init__(self, *transitions):
-        self.transitions = list(*transitions)
-
-    def __repr__(self):
-        return "{}({!r})".format(type(self).__name__, self.transitions)
-
-    def __or__(self, other):
-        self.add_transitions(other)
-        return self
-
-    def add_transitions(self, transition):
-        if isinstance(transition, TransitionList):
-            transition = transition.transitions
-        transitions = ensure_iterable(transition)
-
-        for transition in transitions:
-            self.transitions.append(transition)
-
-        return self
-
-    def __getitem__(self, index):
-        return self.transitions[index]
-
-    def __len__(self):
-        return len(self.transitions)
-
-    def __call__(self, f):
-        for transition in self.transitions:
-            func = transition._get_promisse_to_machine(f)
-            transition.before.add(func)
-        return self
-
-
-class State(object):
-    """
-    A state in a state machine describes a particular behaviour of the machine.
-    When we say that a machine is “in” a state, it means that the machine behaves
-    in the way that state describes.
-    """
-
-    def __init__(
-        self, name, value=None, initial=False, final=False, enter=None, exit=None
-    ):
-        # type: (Text, Optional[V], bool, bool, Optional[Any], Optional[Any]) -> None
-        self.name = name
-        self.value = value
-        self._initial = initial
-        self.identifier = None  # type: Optional[Text]
-        self.transitions = TransitionList()
-        self._final = final
-        self.enter = Callbacks().add(enter)
-        self.exit = Callbacks().add(exit)
-
-    def setup(self, machine):
-        resolver = resolver_factory(machine, machine.model)
-        self.enter.setup(resolver)
-        self.exit.setup(resolver)
-
-        self.enter.add(
-            ["on_enter_state", "on_enter_{}".format(self.identifier)],
-            resolver,
-            suppress_errors=True,
-        )
-        self.exit.add(
-            ["on_exit_state", "on_exit_{}".format(self.identifier)],
-            resolver,
-            suppress_errors=True,
-        )
-
-    def __repr__(self):
-        return "{}({!r}, identifier={!r}, value={!r}, initial={!r}, final={!r})".format(
-            type(self).__name__,
-            self.name,
-            self.identifier,
-            self.value,
-            self.initial,
-            self.final,
-        )
-
-    def __get__(self, machine, owner):
-        return self
-
-    def __set__(self, instance, value):
-        "does nothing (not allow overriding)"
-
-    def _set_identifier(self, identifier):
-        self.identifier = identifier
-        if self.value is None:
-            self.value = identifier
-
-    def _to_(self, *states, **kwargs):
-        transitions = TransitionList(
-            Transition(self, state, **kwargs) for state in states
-        )
-        self.transitions.add_transitions(transitions)
-        return transitions
-
-    def _from_(self, *states, **kwargs):
-        transitions = TransitionList()
-        for origin in states:
-            transition = Transition(origin, self, **kwargs)
-            origin.transitions.add_transitions(transition)
-            transitions.add_transitions(transition)
-        return transitions
-
-    def _get_proxy_method_to_itself(self, method):
-        def proxy(*states, **kwargs):
-            return method(*states, **kwargs)
-
-        def proxy_to_itself(**kwargs):
-            return proxy(self, **kwargs)
-
-        proxy.itself = proxy_to_itself
-        return proxy
-
-    @property
-    def to(self):
-        """Create transitions to the given destination states.
-
-        .. code::
-
-            <origin_state>.to(*<destination_state>)
-
-        """
-        return self._get_proxy_method_to_itself(self._to_)
-
-    @property
-    def from_(self):
-        return self._get_proxy_method_to_itself(self._from_)
-
-    @property
-    def initial(self):
-        return self._initial
-
-    @property
-    def final(self):
-        return self._final
-
-
-def check_state_factory(state):
-    "Return a property that checks if the current state is the desired state"
-
-    @property
-    def is_in_state(self):
-        # type: (BaseStateMachine) -> bool
-        return bool(self.current_state == state)
-
-    return is_in_state
-
-
-class EventData(object):
-    def __init__(self, machine, event, *args, **kwargs):
-        self.machine = machine
-        self.event = event
-        self.source = None
-        self.state = None
-        self.model = None
-        self.transition = None
-        self.executed = False
-
-        # runtime and error
-        self.args = args
-        self.kwargs = kwargs
-        self.error = None
-        self.result = None
-
-    def __repr__(self):
-        return "{}({!r})".format(type(self).__name__, self.__dict__)
-
-    @property
-    def extended_kwargs(self):
-        kwargs = self.kwargs.copy()
-        kwargs["event_data"] = self
-        kwargs["event"] = self.event
-        kwargs["source"] = self.source
-        kwargs["state"] = self.state
-        kwargs["model"] = self.model
-        kwargs["transition"] = self.transition
-        return kwargs
-
-
-class OrderedDefaultDict(OrderedDict):  # python <= 3.5 compat layer
-    factory = TransitionList
-
-    def __missing__(self, key):
-        self[key] = value = self.factory()
-        return value
-
-
-class Event(object):
-    def __init__(self, name):
-        self.name = name
-        self._transitions = OrderedDefaultDict()
-
-    def __repr__(self):
-        return "{}({!r}, {!r})".format(
-            type(self).__name__, self.name, self._transitions
-        )
-
-    def __get__(self, machine, owner):
-        def trigger_callback(*args, **kwargs):
-            return self.trigger(machine, *args, **kwargs)
-
-        return CallableInstance(self, func=trigger_callback)
-
-    def __set__(self, instance, value):
-        "does nothing (not allow overriding)"
-
-    def add_transition(self, transition):
-        transition.trigger = self.name
-        self._transitions[transition.source].add_transitions(transition)
-
-    def add_transitions(self, transitions):
-        transitions = ensure_iterable(transitions)
-        for transition in transitions:
-            self.add_transition(transition)
-
-    @property
-    def identifier(self):
-        warnings.warn(
-            "identifier is deprecated. Use `name` instead", DeprecationWarning
-        )
-        return self.name
-
-    @property
-    def validators(self):
-        warnings.warn(
-            "`validators` is deprecated. Use `conditions` instead", DeprecationWarning
-        )
-        return list(
-            {
-                validator
-                for transition in self.transitions
-                for validator in transition.validators
-            }
-        )
-
-    @validators.setter
-    def validators(self, value):
-        warnings.warn(
-            "`validators` is deprecated. Use `conditions` instead", DeprecationWarning
-        )
-        for transition in self.transitions:
-            transition.validators = value
-
-    @property
-    def transitions(self):
-        return [
-            transition
-            for transition_list in self._transitions.values()
-            for transition in transition_list
-        ]
-
-    def _check_is_valid_source(self, state):
-        if state not in self._transitions:
-            raise TransitionNotAllowed(self, state)
-
-    def trigger(self, machine, *args, **kwargs):
-        event_data = EventData(machine, self, *args, **kwargs)
-
-        def trigger_wrapper():
-            """Wrapper that captures event_data as closure."""
-            return self._trigger(event_data)
-
-        return machine._process(trigger_wrapper)
-
-    def _trigger(self, event_data):
-        event_data.source = event_data.machine.current_state
-        event_data.state = event_data.machine.current_state
-        event_data.model = event_data.machine.model
-
-        try:
-            self._check_is_valid_source(event_data.state)
-            self._process(event_data)
-        except Exception as error:
-            event_data.error = error
-            # TODO: Log errors
-            # TODO: Allow exception handlers
-            raise
-        return event_data.result
-
-    def _process(self, event_data):
-        for transition in self._transitions[event_data.state]:
-            event_data.transition = transition
-            if transition.execute(event_data):
-                event_data.executed = True
-                break
-        else:
-            raise TransitionNotAllowed(self, event_data.state)
+from .model import Model
+from .utils import ugettext as _, check_state_factory
+from .state import State
+from .transition import Transition
+from .transition_list import TransitionList
 
 
 class StateMachineMetaclass(type):
@@ -504,14 +78,6 @@ class StateMachineMetaclass(type):
         return list(self._events.values())
 
 
-class Model(Generic[V]):
-    def __init__(self):
-        self.state = None  # type: Optional[V]
-
-    def __repr__(self):
-        return "Model(state={})".format(self.state)
-
-
 class BaseStateMachine(object):
 
     _events = {}  # type: Dict[Any, Any]
@@ -519,7 +85,6 @@ class BaseStateMachine(object):
     states_map = {}  # type: Dict[Any, State]
 
     def __init__(self, model=None, state_field="state", start_value=None):
-        # type: (Any, str, Optional[V]) -> None
         self.model = model if model else Model()
         self.state_field = state_field
         self.start_value = start_value
@@ -546,7 +111,9 @@ class BaseStateMachine(object):
 
     def _activate_initial_state(self, initials):
 
-        current_state_value = self.start_value if self.start_value else self.initial_state.value
+        current_state_value = (
+            self.start_value if self.start_value else self.initial_state.value
+        )
         if self.current_state_value is None:
 
             try:
@@ -613,13 +180,11 @@ class BaseStateMachine(object):
 
     @property
     def current_state_value(self):
-        # type: () -> V
-        value = getattr(self.model, self.state_field, None)  # type: V
+        value = getattr(self.model, self.state_field, None)
         return value
 
     @current_state_value.setter
     def current_state_value(self, value):
-        # type: (V) -> None
         if value not in self.states_map:
             raise InvalidStateValue(value)
         setattr(self.model, self.state_field, value)
@@ -677,8 +242,7 @@ class BaseStateMachine(object):
         return result
 
     def get_event(self, trigger):
-        # type: (Text) -> CallableInstance
-        event = getattr(self, trigger, None)  # type: CallableInstance
+        event = getattr(self, trigger, None)
         if trigger not in self._events or event is None:
             raise InvalidTransitionIdentifier(trigger)
         return event

--- a/statemachine/transition.py
+++ b/statemachine/transition.py
@@ -1,0 +1,104 @@
+# coding: utf-8
+import warnings
+from functools import wraps
+from weakref import ref
+
+from .callbacks import Callbacks, ConditionWrapper, methodcaller, resolver_factory
+
+
+class Transition(object):
+    """
+    A transition holds reference to the source and destination state.
+    """
+
+    def __init__(
+        self,
+        source,
+        destination,
+        trigger=None,
+        validators=None,
+        conditions=None,
+        unless=None,
+        on_execute=None,
+        before=None,
+        after=None,
+    ):
+        self.source = source
+        self.destination = destination
+        self.trigger = trigger
+        self.validators = validators if validators is not None else []
+        self.before = (
+            Callbacks()
+            .add("before_transition", suppress_errors=True)
+            .add(before)
+            .add(on_execute)
+        )
+        self.after = Callbacks().add(after)
+        self.conditions = (
+            Callbacks(factory=ConditionWrapper)
+            .add(conditions)
+            .add(unless, expected_value=False)
+        )
+        self.machine = None
+
+    def __repr__(self):
+        return "{}({!r}, {!r}, trigger={!r})".format(
+            type(self).__name__, self.source, self.destination, self.trigger
+        )
+
+    def _get_promisse_to_machine(self, func):
+
+        decorated = methodcaller(func)
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return decorated(self.machine(), *args, **kwargs)
+
+        return wrapper
+
+    def setup(self, machine):
+        self.machine = ref(machine)
+        resolver = resolver_factory(machine, machine.model)
+        self.before.setup(resolver)
+        self.after.setup(resolver)
+        self.conditions.setup(resolver)
+
+        self.before.add(
+            [
+                "before_{}".format(self.trigger),
+                "on_{}".format(self.trigger),
+            ],
+            resolver,
+            suppress_errors=True,
+        )
+        self.after.add(
+            ["after_{}".format(self.trigger), "after_transition"],
+            resolver,
+            suppress_errors=True,
+        )
+
+    def _validate(self, *args, **kwargs):
+        for validator in self.validators:
+            validator(*args, **kwargs)
+
+    def _eval_conditions(self, event_data):
+        return all(
+            condition(*event_data.args, **event_data.extended_kwargs)
+            for condition in self.conditions
+        )
+
+    @property
+    def identifier(self):
+        warnings.warn(
+            "identifier is deprecated. Use `trigger` instead", DeprecationWarning
+        )
+        return self.trigger
+
+    def execute(self, event_data):
+        self._validate(*event_data.args, **event_data.kwargs)
+        if not self._eval_conditions(event_data):
+            return False
+
+        result = event_data.machine._activate(event_data)
+        event_data.result = result
+        return True

--- a/statemachine/transition_list.py
+++ b/statemachine/transition_list.py
@@ -1,0 +1,35 @@
+from .utils import ensure_iterable
+
+
+class TransitionList(object):
+    def __init__(self, *transitions):
+        self.transitions = list(*transitions)
+
+    def __repr__(self):
+        return "{}({!r})".format(type(self).__name__, self.transitions)
+
+    def __or__(self, other):
+        self.add_transitions(other)
+        return self
+
+    def add_transitions(self, transition):
+        if isinstance(transition, TransitionList):
+            transition = transition.transitions
+        transitions = ensure_iterable(transition)
+
+        for transition in transitions:
+            self.transitions.append(transition)
+
+        return self
+
+    def __getitem__(self, index):
+        return self.transitions[index]
+
+    def __len__(self):
+        return len(self.transitions)
+
+    def __call__(self, f):
+        for transition in self.transitions:
+            func = transition._get_promisse_to_machine(f)
+            transition.before.add(func)
+        return self

--- a/statemachine/utils.py
+++ b/statemachine/utils.py
@@ -21,3 +21,13 @@ def ensure_iterable(obj):
         return iter(obj)
     except TypeError:
         return [obj]
+
+
+def check_state_factory(state):
+    "Return a property that checks if the current state is the desired state"
+
+    @property
+    def is_in_state(self):
+        return bool(self.current_state == state)
+
+    return is_in_state

--- a/tests/examples/order_control_machine.py
+++ b/tests/examples/order_control_machine.py
@@ -8,10 +8,9 @@ class OrderControl(StateMachine):  # type: ignore
     completed = State("Completed", final=True)
 
     add_to_order = waiting_for_payment.to(waiting_for_payment)
-    receive_payment = (
-        waiting_for_payment.to(processing, conditions="payments_enough")
-        | waiting_for_payment.to(waiting_for_payment, unless="payments_enough")
-    )
+    receive_payment = waiting_for_payment.to(
+        processing, conditions="payments_enough"
+    ) | waiting_for_payment.to(waiting_for_payment, unless="payments_enough")
     process_order = processing.to(shipping, conditions="payment_received")
     ship_order = shipping.to(completed)
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -5,7 +5,6 @@ from statemachine import StateMachine, State
 
 
 class TestActions:
-
     def test_should_return_all_before_results(self):
 
         spy = mock.Mock(side_effect=lambda x: x)
@@ -97,34 +96,34 @@ class TestActions:
 
         result = machine.go()
         assert result == [
-            'before_transition',
-            'before_go_inline_1',
-            'before_go_inline_2',
-            'on_execute_1',
-            'on_execute_2',
-            'before_go',
-            'on_go',
+            "before_transition",
+            "before_go_inline_1",
+            "before_go_inline_2",
+            "on_execute_1",
+            "on_execute_2",
+            "before_go",
+            "on_go",
         ]
 
         # ensure correct call order
         assert spy.call_args_list == [
-            mock.call('on_enter_state'),
-            mock.call('on_enter_initial'),
-            mock.call('condition_1'),
-            mock.call('condition_2'),
-            mock.call('before_transition'),
-            mock.call('before_go_inline_1'),
-            mock.call('before_go_inline_2'),
-            mock.call('on_execute_1'),
-            mock.call('on_execute_2'),
-            mock.call('before_go'),
-            mock.call('on_go'),
-            mock.call('on_exit_state'),
-            mock.call('on_exit_initial'),
-            mock.call('on_enter_state'),
-            mock.call('on_enter_final'),
-            mock.call('after_go_inline_1'),
-            mock.call('after_go_inline_2'),
-            mock.call('after_go'),
-            mock.call('after_transition'),
+            mock.call("on_enter_state"),
+            mock.call("on_enter_initial"),
+            mock.call("condition_1"),
+            mock.call("condition_2"),
+            mock.call("before_transition"),
+            mock.call("before_go_inline_1"),
+            mock.call("before_go_inline_2"),
+            mock.call("on_execute_1"),
+            mock.call("on_execute_2"),
+            mock.call("before_go"),
+            mock.call("on_go"),
+            mock.call("on_exit_state"),
+            mock.call("on_exit_initial"),
+            mock.call("on_enter_state"),
+            mock.call("on_enter_final"),
+            mock.call("after_go_inline_1"),
+            mock.call("after_go_inline_2"),
+            mock.call("after_go"),
+            mock.call("after_transition"),
         ]

--- a/tests/test_callable_instance.py
+++ b/tests/test_callable_instance.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 import mock
 
-from statemachine.statemachine import CallableInstance
+from statemachine.callable_proxy import CallableInstance
 
 
 def test_callable_should_override_kwargs():

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -50,7 +50,10 @@ class TestCallbacksMachinery:
         callbacks(1, 2, 3, a="x", b="y")
 
         resolver.assert_has_calls(
-            [mock.call("my_method"), mock.call("other_method"), ]
+            [
+                mock.call("my_method"),
+                mock.call("other_method"),
+            ]
         )
         assert func.call_args_list == [
             mock.call(1, 2, 3, a="x", b="y"),
@@ -80,10 +83,14 @@ class TestCallbacksMachinery:
 
         resolver = resolver_factory(object())
         if suppress_errors:
-            callbacks.add("this_does_no_exist", resolver, suppress_errors=suppress_errors)
+            callbacks.add(
+                "this_does_no_exist", resolver, suppress_errors=suppress_errors
+            )
         else:
             with pytest.raises(InvalidDefinition):
-                callbacks.add("this_does_no_exist", resolver, suppress_errors=suppress_errors)
+                callbacks.add(
+                    "this_does_no_exist", resolver, suppress_errors=suppress_errors
+                )
 
     def test_collect_results(self):
         callbacks = Callbacks()

--- a/tests/test_multiple_destinations.py
+++ b/tests/test_multiple_destinations.py
@@ -188,11 +188,18 @@ def test_multiple_values_returned_with_multiple_destinations():
 
     machine = ApprovalMachine()
 
-    assert machine.validate() == (1, 2,)
+    assert machine.validate() == (
+        1,
+        2,
+    )
 
 
 @pytest.mark.parametrize(
-    "payment_failed, expected_state", [(False, "paid"), (True, "failed"), ]
+    "payment_failed, expected_state",
+    [
+        (False, "paid"),
+        (True, "failed"),
+    ],
 )
 def test_multiple_destinations_using_or_starting_from_same_origin(
     payment_failed, expected_state

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -126,7 +126,11 @@ def test_should_change_state_with_multiple_machine_instances(campaign_machine):
 
 
 @pytest.mark.parametrize(
-    "current_state, transition", [("draft", "deliver"), ("closed", "add_job"), ]
+    "current_state, transition",
+    [
+        ("draft", "deliver"),
+        ("closed", "add_job"),
+    ],
 )
 def test_call_to_transition_that_is_not_in_the_current_state_should_raise_exception(
     campaign_machine, current_state, transition

--- a/tests/test_statemachine_bounded_transitions.py
+++ b/tests/test_statemachine_bounded_transitions.py
@@ -39,7 +39,8 @@ def state_machine(event_mock):
 
 
 def test_run_transition_pass_arguments_to_sub_transitions(
-    state_machine, event_mock,
+    state_machine,
+    event_mock,
 ):
     model = MyModel(state="draft")
     machine = state_machine(model)

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -63,7 +63,11 @@ def test_transition_as_decorator_should_call_method_before_activating_state(
 
 
 @pytest.mark.parametrize(
-    "machine_name", ["traffic_light_machine", "reverse_traffic_light_machine", ]
+    "machine_name",
+    [
+        "traffic_light_machine",
+        "reverse_traffic_light_machine",
+    ],
 )
 def test_cycle_transitions(request, machine_name):
     machine_class = request.getfixturevalue(machine_name)
@@ -158,7 +162,14 @@ def test_transitions_to_the_same_estate_as_itself():
 
 
 class TestReverseTransition(object):
-    @pytest.mark.parametrize("initial_state", ["green", "yellow", "red", ])
+    @pytest.mark.parametrize(
+        "initial_state",
+        [
+            "green",
+            "yellow",
+            "red",
+        ],
+    )
     def test_reverse_transition(self, reverse_traffic_light_machine, initial_state):
         machine = reverse_traffic_light_machine(start_value=initial_state)
         assert machine.current_state.identifier == initial_state


### PR DESCRIPTION
Extract code to medicated modules.

The main module `statemachine.py` was huge, extracting each class to its own module.