### PR TITLE
Fix TransitionList.__or__ mutating itself instead of returning a new instance. Closes #308.

### DIFF
--- a/statemachine/transition_list.py
+++ b/statemachine/transition_list.py
@@ -4,15 +4,14 @@ from .utils import ensure_iterable
 
 
 class TransitionList(object):
-    def __init__(self, *transitions):
-        self.transitions = list(*transitions)
+    def __init__(self, transitions=None):
+        self.transitions = list(transitions) if transitions else []
 
     def __repr__(self):
         return "{}({!r})".format(type(self).__name__, self.transitions)
 
     def __or__(self, other):
-        self.add_transitions(other)
-        return self
+        return TransitionList(self.transitions).add_transitions(other)
 
     def add_transitions(self, transition):
         if isinstance(transition, TransitionList):

--- a/tests/test_transition_list.py
+++ b/tests/test_transition_list.py
@@ -1,0 +1,23 @@
+from statemachine import State
+
+
+def test_transition_list_or_operator():
+    s1 = State("s1", initial=True)
+    s2 = State("s2")
+    s3 = State("s3")
+    s4 = State("s4", final=True)
+
+    t12 = s1.to(s2)
+    t23 = s2.to(s3)
+    t34 = s3.to(s4)
+
+    cycle = t12 | t23 | t34
+
+    assert [(t.source.name, t.target.name) for t in t12] == [("s1", "s2")]
+    assert [(t.source.name, t.target.name) for t in t23] == [("s2", "s3")]
+    assert [(t.source.name, t.target.name) for t in t34] == [("s3", "s4")]
+    assert [(t.source.name, t.target.name) for t in cycle] == [
+        ("s1", "s2"),
+        ("s2", "s3"),
+        ("s3", "s4"),
+    ]


### PR DESCRIPTION
Fix `TransitionList.__or__` mutating itself instead of returning a new instance. 

Closes #308.