### PR TITLE
feat: Generate StateMachine diagram from cmd line

### DIFF
--- a/docs/diagram.md
+++ b/docs/diagram.md
@@ -29,7 +29,7 @@ Graphviz. For example, on Debian-based systems (such as Ubuntu), you can use the
 
 ```
 
-## How to generate a diagram
+## How to generate a diagram at runtime
 
 
 ```py
@@ -79,6 +79,37 @@ The current state is also highlighted:
 ```
 
 ![OrderControl](images/order_control_machine_processing.png)
+
+
+## Generate from the command line
+
+You can also generate a diagram from the command line using the `statemachine.contrib.diagram` as a module.
+
+```bash
+❯ python -m statemachine.contrib.diagram --help
+usage: diagram.py [OPTION] <classpath> <out>
+
+Generate diagrams for StateMachine classes.
+
+positional arguments:
+  classpath   A fully-qualified dotted path to the StateMachine class.
+  out         File to generate the image using extension as the output format.
+
+optional arguments:
+  -h, --help  show this help message and exit
+```
+
+Example:
+
+```bash
+python -m statemachine.contrib.diagram tests.examples.traffic_light_machine.TrafficLightMachine m.png
+```
+
+```{note}
+Supported formats include: `dia`, `dot`, `fig`, `gif`, `jpg`, `pdf`, `png`, `ps`, `svg` and many others.
+Please see [pydot](https://github.com/pydot/pydot) and [Graphviz](https://graphviz.org/) for a
+complete list.
+```
 
 
 ## JupyterLab / Jupyter integration

--- a/tests/test_contrib_diagram.py
+++ b/tests/test_contrib_diagram.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from statemachine.contrib.diagram import DotGraphMachine
+from statemachine.contrib.diagram import DotGraphMachine, main
 
 
 @pytest.fixture(params=[
@@ -37,3 +37,23 @@ def test_machine_dot(OrderControl):
 
     dot_str = dot.to_string()  # or dot.to_string()
     assert dot_str.startswith("digraph list {")
+
+
+class TestDiagramCmdLine:
+
+    def test_generate_image(self, tmp_path):
+        out = tmp_path / 'sm.svg'
+
+        main(["tests.examples.traffic_light_machine.TrafficLightMachine", str(out)])
+
+        assert out.read_text().startswith(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n<!DOCTYPE svg'
+        )
+
+    def test_generate_complain_about_bad_sm_path(self, capsys, tmp_path):
+        out = tmp_path / 'sm.svg'
+
+        with pytest.raises(ValueError) as e:
+            main(["tests.examples.traffic_light_machine.TrafficLightMachineXXX", str(out)])
+
+        assert e.match("TrafficLightMachineXXX is not a subclass of StateMachine")


### PR DESCRIPTION
Generate a `StateMachine` diagram from the command line.

```bash
❯ python -m statemachine.contrib.diagram --help
usage: diagram.py [OPTION] <classpath> <out>
Generate diagrams for StateMachine classes.
positional arguments:
  classpath   A fully-qualified dotted path to the StateMachine class.
  out         File to generate the image using extension as the output format.
optional arguments:
  -h, --help  show this help message and exit
```

### Examples:

```
python -m statemachine.contrib.diagram tests.examples.guess_the_number_machine.GuessTheNumberMachine number.pdf
```

[number.pdf](https://github.com/fgmacedo/python-statemachine/files/10394149/number.pdf)

``` bash
python -m statemachine.contrib.diagram tests.examples.guess_the_number_machine.GuessTheNumberMachine number.png
```

![number](https://user-images.githubusercontent.com/281007/211859301-e72d2b40-1624-4362-9bba-aa6099c2ba69.png)
