### PR TITLE
fix: inspect.getargspec removed on 3.11. Closes #316

### DIFF
--- a/statemachine/dispatcher.py
+++ b/statemachine/dispatcher.py
@@ -31,8 +31,11 @@ def methodcaller(method):
     # args is a list of the argument names (it may contain nested lists)
     # varargs and keywords are the names of the * and ** arguments or None
     # defaults is a tuple of default argument values or None if there are no default arguments
-    spec = inspect.getargspec(method)
-    keywords = spec.keywords
+    try:
+        spec = inspect.getfullargspec(method)
+    except AttributeError:  # pragma: no cover
+        spec = inspect.getargspec(method)
+    keywords = getattr(spec, "varkw", getattr(spec, "keywords", None))
     expected_args = list(spec.args)
     expected_kwargs = spec.defaults or {}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, lint
+envlist = py27, py35, py36, py37, py38, py39, py310, py311, lint
 
 [testenv]
 setenv =
@@ -28,8 +28,20 @@ commands =
 
 basepython =
     lint: python3.8
+    py311: python3.11
+    py310: python3.10
+    py39: python3.9
     py38: python3.8
     py37: python3.7
     py36: python3.6
     py35: python3.5
     py27: python2.7
+
+[testenv:py311]
+deps =
+    pytest>5
+    pytest-cov
+    pytest-flake8
+    flake8==3.7.9
+    pydot
+    mock


### PR DESCRIPTION
Fixes usage of `inspect.getargspec` that was removed on python 3.11. Closes #316