### PR TITLE
fix: Test matrix python version not being cached properly

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
     - name: Install dependencies
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       run: poetry install --no-interaction --no-root

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
+import sys
 from datetime import datetime
 
 import pytest
+
+# We support Python 3.8+ positional only syntax
+if sys.version_info[:2] < (3, 8):
+    collect_ignore_glob = ["*_positional_only.py"]
 
 
 @pytest.fixture()

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,5 +1,4 @@
 import inspect
-import sys
 
 import pytest
 
@@ -147,36 +146,6 @@ class TestSignatureAdapter:
         ],
     )
     def test_wrap_fn_single_positional_parameter(self, func, args, kwargs, expected):
-
-        wrapped_func = SignatureAdapter.wrap(func)
-
-        if inspect.isclass(expected) and issubclass(expected, Exception):
-            with pytest.raises(expected):
-                wrapped_func(*args, **kwargs)
-        else:
-            assert wrapped_func(*args, **kwargs) == expected
-
-    @pytest.mark.parametrize(
-        ("args", "kwargs", "expected"),
-        [
-            ([], {}, TypeError),
-            ([1, 2, 3], {}, TypeError),
-            ([1, 2], {"kw_only_param": 42}, (1, 2, 42)),
-            ([1], {"pos_or_kw_param": 21, "kw_only_param": 42}, (1, 21, 42)),
-            (
-                [],
-                {"pos_only": 10, "pos_or_kw_param": 21, "kw_only_param": 42},
-                TypeError,
-            ),
-        ],
-    )
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8), reason="requires python3.8 or higher"
-    )
-    def test_positional_ony(self, args, kwargs, expected):
-        def func(pos_only, /, pos_or_kw_param, *, kw_only_param):
-            # https://peps.python.org/pep-0570/
-            return pos_only, pos_or_kw_param, kw_only_param
 
         wrapped_func = SignatureAdapter.wrap(func)
 

--- a/tests/test_signature_positional_only.py
+++ b/tests/test_signature_positional_only.py
@@ -1,0 +1,34 @@
+import inspect
+
+import pytest
+
+from statemachine.signature import SignatureAdapter
+
+
+class TestSignatureAdapter:
+    @pytest.mark.parametrize(
+        ("args", "kwargs", "expected"),
+        [
+            ([], {}, TypeError),
+            ([1, 2, 3], {}, TypeError),
+            ([1, 2], {"kw_only_param": 42}, (1, 2, 42)),
+            ([1], {"pos_or_kw_param": 21, "kw_only_param": 42}, (1, 21, 42)),
+            (
+                [],
+                {"pos_only": 10, "pos_or_kw_param": 21, "kw_only_param": 42},
+                TypeError,
+            ),
+        ],
+    )
+    def test_positional_ony(self, args, kwargs, expected):
+        def func(pos_only, /, pos_or_kw_param, *, kw_only_param):
+            # https://peps.python.org/pep-0570/
+            return pos_only, pos_or_kw_param, kw_only_param
+
+        wrapped_func = SignatureAdapter.wrap(func)
+
+        if inspect.isclass(expected) and issubclass(expected, Exception):
+            with pytest.raises(expected):
+                wrapped_func(*args, **kwargs)
+        else:
+            assert wrapped_func(*args, **kwargs) == expected


### PR DESCRIPTION
Due to a cache-key error, we're restoring and running the tests against the last updated virtualenv. This was causing random errors on the `test_signature.py` test that only exists on Python3.8+ when running on the python3.7 venv.

Since there's no way to conditionally ignore `SyntaxError` as the module is not importable (https://github.com/pytest-dev/pytest/issues/2817), we've isolated the 3.8+ tests on its own module that is not ignored when running the 3.7 suite.