### PR TITLE
feat: Allow using events on callbacks

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -133,6 +133,12 @@ Use the `enter` or `exit` params available on the `State` constructor.
 
 ```
 
+```{hint}
+It's also possible to use an event name as action.
+
+**Be careful to not introduce recursion errors** that will raise `RecursionError` exception.
+```
+
 ### Bind state actions using decorator syntax
 
 
@@ -211,6 +217,12 @@ model, using the patterns:
 ...     def loop_completed(self):
 ...         pass
 
+```
+
+```{hint}
+It's also possible to use an event name as action to chain transitions.
+
+**Be careful to not introduce recursion errors**, like `loop = initial.to.itself(after="loop")`, that will raise `RecursionError` exception.
 ```
 
 ### Bind event actions using decorator syntax

--- a/docs/releases/2.0.0.md
+++ b/docs/releases/2.0.0.md
@@ -75,6 +75,7 @@ See {ref}`internal transition` for more details.
   guards using decorators is now possible.
 - [#331](https://github.com/fgmacedo/python-statemachine/pull/331): Added a way to generate diagrams using [QuickChart.io](https://quickchart.io) instead of GraphViz. See {ref}`diagrams` for more details.
 - [#353](https://github.com/fgmacedo/python-statemachine/pull/353): Support for abstract state machine classes, so you can subclass `StateMachine` to add behavior on your own base class. Abstract `StateMachine` cannot be instantiated.
+- [#355](https://github.com/fgmacedo/python-statemachine/pull/355): Now is possible to trigger an event as an action by registering the event name as the callback param.
 
 ## Bugfixes in 2.0
 

--- a/statemachine/dispatcher.py
+++ b/statemachine/dispatcher.py
@@ -37,7 +37,7 @@ def _get_func_by_attr(attr, *configs):
     return func, config.obj
 
 
-def ensure_callable(attr, *objects):
+def ensure_callable(attr, *objects):  # noqa: C901
     """Ensure that `attr` is a callable, if not, tries to retrieve one from any of the given
     `objects`.
 
@@ -63,6 +63,15 @@ def ensure_callable(attr, *objects):
 
         def wrapper(*args, **kwargs):
             return getter(obj)
+
+        return wrapper
+
+    if getattr(func, "_is_sm_event", False):
+        "Events already have the 'machine' parameter defined."
+
+        def wrapper(*args, **kwargs):
+            kwargs.pop("machine")
+            return func(*args, **kwargs)
 
         return wrapper
 

--- a/statemachine/event_data.py
+++ b/statemachine/event_data.py
@@ -1,43 +1,77 @@
+from dataclasses import dataclass
+from dataclasses import field
 from typing import TYPE_CHECKING
+from typing import Any
 
 if TYPE_CHECKING:
+    from .state import State
     from .statemachine import StateMachine
     from .transition import Transition
 
 
+@dataclass
+class TriggerData:
+    machine: "StateMachine"
+    event: str
+    """The Event that was triggered."""
+
+    model: Any = field(init=False)
+    """A reference to the underlying model that holds the current State."""
+
+    args: tuple = field(default_factory=tuple)
+    """All positional arguments provided on the Event."""
+
+    kwargs: dict = field(default_factory=dict)
+    """All keyword arguments provided on the Event."""
+
+    def __post_init__(self):
+        self.model = self.machine.model
+
+
+@dataclass
 class EventData:
-    def __init__(self, machine: "StateMachine", event: str, *args, **kwargs):
-        self.machine = machine
-        self.event = event
-        self.source = kwargs.get("source", None)
-        self.state = kwargs.get("state", None)
-        self.model = kwargs.get("model", None)
-        self.executed = False
-        self.transition: Transition | None = None
-        self.target = None
-        self._set_transition(kwargs.get("transition", None))
+    trigger_data: TriggerData
+    transition: "Transition"
+    """The Transition instance that was activated by the Event."""
 
-        # runtime and error
-        self.args = args
-        self.kwargs = kwargs
-        self.error = None
-        self.result = None
+    state: "State" = field(init=False)
+    """The current State of the state machine."""
 
-    def __repr__(self):
-        return f"{type(self).__name__}({self.__dict__!r})"
+    source: "State" = field(init=False)
+    """The State the state machine was in when the Event started."""
 
-    def _set_transition(self, transition: "Transition"):
-        self.transition = transition
-        self.target = getattr(transition, "target", None)
+    target: "State" = field(init=False)
+    """The destination State of the transition."""
+
+    result: "Any | None" = None
+    executed: bool = False
+
+    def __post_init__(self):
+        self.state = self.transition.source
+        self.source = self.transition.source
+        self.target = self.transition.target
+
+    @property
+    def machine(self):
+        return self.trigger_data.machine
+
+    @property
+    def event(self):
+        return self.trigger_data.event
+
+    @property
+    def args(self):
+        return self.trigger_data.args
 
     @property
     def extended_kwargs(self):
-        kwargs = self.kwargs.copy()
+        kwargs = self.trigger_data.kwargs.copy()
         kwargs["event_data"] = self
-        kwargs["event"] = self.event
-        kwargs["source"] = self.source
-        kwargs["state"] = self.state
-        kwargs["model"] = self.model
+        kwargs["machine"] = self.trigger_data.machine
+        kwargs["event"] = self.trigger_data.event
+        kwargs["model"] = self.trigger_data.model
         kwargs["transition"] = self.transition
+        kwargs["state"] = self.state
+        kwargs["source"] = self.source
         kwargs["target"] = self.target
         return kwargs

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING  # noqa: F401, I001
 from .dispatcher import ObjectConfig
 from .dispatcher import resolver_factory
 from .event import Event
+from .event_data import TriggerData
 from .event_data import EventData
 from .exceptions import InvalidStateValue
 from .exceptions import InvalidDefinition
@@ -62,30 +63,29 @@ class StateMachine(metaclass=StateMachineMetaclass):
             initial_transition.before.clear()
             initial_transition.on.clear()
             initial_transition.after.clear()
+
             event_data = EventData(
-                self,
-                initial_transition.event,
+                trigger_data=TriggerData(
+                    machine=self,
+                    event=initial_transition.event,
+                ),
                 transition=initial_transition,
             )
             self._activate(event_data)
 
     def _get_protected_attrs(self):
-        return (
-            {
-                "_abstract",
-                "model",
-                "state_field",
-                "start_value",
-                "initial_state",
-                "final_states",
-                "states",
-                "_events",
-                "states_map",
-                "send",
-            }
-            | {s.id for s in self.states}
-            | set(self._events.keys())
-        )
+        return {
+            "_abstract",
+            "model",
+            "state_field",
+            "start_value",
+            "initial_state",
+            "final_states",
+            "states",
+            "_events",
+            "states_map",
+            "send",
+        } | {s.id for s in self.states}
 
     def _visit_states_and_transitions(self, visitor):
         for state in self.states:
@@ -165,7 +165,6 @@ class StateMachine(metaclass=StateMachineMetaclass):
 
     def _activate(self, event_data: EventData):
         transition = event_data.transition
-        assert transition is not None
         source = event_data.state
         target = transition.target
 

--- a/statemachine/transition.py
+++ b/statemachine/transition.py
@@ -1,10 +1,13 @@
 from functools import partial
+from typing import TYPE_CHECKING
 
 from .callbacks import Callbacks
 from .callbacks import ConditionWrapper
-from .event_data import EventData
 from .events import Events
 from .exceptions import InvalidDefinition
+
+if TYPE_CHECKING:
+    from .event_data import EventData
 
 
 class Transition:
@@ -119,7 +122,7 @@ class Transition:
     def add_event(self, value):
         self._events.add(value)
 
-    def execute(self, event_data: EventData):
+    def execute(self, event_data: "EventData"):
         self.validators.call(*event_data.args, **event_data.extended_kwargs)
         if not self._eval_cond(event_data):
             return False

--- a/tests/examples/order_control_rich_model_machine.py
+++ b/tests/examples/order_control_rich_model_machine.py
@@ -19,7 +19,7 @@ class Order:
     def payments_enough(self, amount):
         return sum(self.payments) + amount >= self.order_total
 
-    def add_to_order(self, amount):
+    def before_add_to_order(self, amount):
         self.order_total += amount
         return self.order_total
 
@@ -40,7 +40,7 @@ class OrderControl(StateMachine):
     shipping = State()
     completed = State(final=True)
 
-    add_to_order = waiting_for_payment.to(waiting_for_payment, before="add_to_order")
+    add_to_order = waiting_for_payment.to(waiting_for_payment)
     receive_payment = waiting_for_payment.to(
         processing, cond="payments_enough"
     ) | waiting_for_payment.to(waiting_for_payment, unless="payments_enough")


### PR DESCRIPTION
Allows the usage of `events` on callbacks.

```py
    class ChainedSM(StateMachine):
        a = State(initial=True)
        b = State()
        c = State()

        t1 = a.to(b, after="t1") | b.to(c)
```

Closes: https://github.com/fgmacedo/python-statemachine/issues/351
