### PR TITLE
feat: Add i18n support. Closes #19

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -37,6 +37,39 @@ Python State Machine could always use more documentation, whether as part of the
 official Python State Machine docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
+### Add a translation
+
+
+Extract a `Portable Object Template` (`POT`) file:
+
+```shell
+pybabel extract statemachine -o statemachine/locale/statemachine.pot
+```
+
+Then, copy the template as a `.po` file into the target locale folder. For example, if you're adding support for Brazilian Portuguese language, the code is `pt_BR`, and the file path should be `statemachine/locale/pt_BR/LC_MESSAGES/statemachine.po`:
+
+```shell
+cp statemachine/locale/statemachine.pot statemachine/locale/pt_BR/LC_MESSAGES/statemachine.po
+```
+
+Then open the `statemachine.po` and translate.
+
+After translation, to get the new language working locally, you need to compile the `.po` files into `.mo`  (binary format). Run:
+
+```shell
+pybabel compile -d statemachine/locale/ -f statemachine.po
+```
+
+
+On Linux (Debian based), you can test changing the `LANGUAGE` environment variable.
+
+```shell
+# If the last line is `Can't guess when in Won.` something went wrong.
+LANGUAGE=pt_BR python tests/examples/guess_the_number_machine.py
+```
+
+Then open a [pull request](https://github.com/fgmacedo/python-statemachine/pulls) with your translation file.
+
 ### Submit Feedback
 
 The best way to send feedback is to file an issue at https://github.com/fgmacedo/python-statemachine/issues.

--- a/docs/releases/2.0.0.md
+++ b/docs/releases/2.0.0.md
@@ -32,6 +32,12 @@ Even if you trigger an event inside an action.
 See {ref}`processing model` for more details.
 ```
 
+### Added support for translations (i18n)
+
+Now the library messages can be translated into any language.
+
+See {ref}`Add a translation` on how to contribute with translations.
+
 ### State names are now optional
 
 {ref}`State` names are now by default derived from the class variable that they are assigned to.

--- a/statemachine/callbacks.py
+++ b/statemachine/callbacks.py
@@ -1,7 +1,7 @@
 from .exceptions import AttrNotFound
 from .exceptions import InvalidDefinition
+from .i18n import _
 from .utils import ensure_iterable
-from .utils import ugettext as _
 
 
 class CallbackWrapper:

--- a/statemachine/dispatcher.py
+++ b/statemachine/dispatcher.py
@@ -3,8 +3,8 @@ from functools import wraps
 from operator import attrgetter
 
 from .exceptions import AttrNotFound
+from .i18n import _
 from .signature import SignatureAdapter
-from .utils import ugettext as _
 
 
 class ObjectConfig(namedtuple("ObjectConfig", "obj skip_attrs")):

--- a/statemachine/exceptions.py
+++ b/statemachine/exceptions.py
@@ -1,4 +1,4 @@
-from .utils import ugettext as _
+from .i18n import _
 
 
 class StateMachineError(Exception):

--- a/statemachine/factory.py
+++ b/statemachine/factory.py
@@ -5,10 +5,10 @@ from .event import Event
 from .event import trigger_event_factory
 from .exceptions import InvalidDefinition
 from .graph import visit_connected_states
+from .i18n import _
 from .state import State
 from .transition import Transition
 from .transition_list import TransitionList
-from .utils import ugettext as _
 
 
 class StateMachineMetaclass(type):

--- a/statemachine/i18n.py
+++ b/statemachine/i18n.py
@@ -1,0 +1,15 @@
+import gettext
+from pathlib import Path
+
+script_dir = Path(__file__).resolve().parent
+locale_dir = script_dir / "locale"
+
+
+def setup_i18n():
+    translate = gettext.translation("statemachine", locale_dir, fallback=True)
+    gettext.bindtextdomain("statemachine", locale_dir)
+    gettext.textdomain("statemachine")
+    return translate.gettext
+
+
+_ = setup_i18n()

--- a/statemachine/locale/en/LC_MESSAGES/statemachine.po
+++ b/statemachine/locale/en/LC_MESSAGES/statemachine.po
@@ -1,0 +1,67 @@
+# This file is distributed under the same license as the PROJECT project.
+# Fernando Macedo <fgmacedo@gmail.com>, 2023.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: 2.0.0\n"
+"Report-Msgid-Bugs-To: fgmacedo@gmail.com\n"
+"POT-Creation-Date: 2023-03-04 16:10-0300\n"
+"PO-Revision-Date: 2023-03-04 16:10-0300\n"
+"Last-Translator: Fernando Macedo <fgmacedo@gmail.com>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
+
+#: statemachine/callbacks.py:56
+msgid "Callback {!r} not property configured."
+msgstr ""
+
+#: statemachine/dispatcher.py:35
+msgid "Did not found name '{}' from model or statemachine"
+msgstr ""
+
+#: statemachine/exceptions.py:17
+msgid "{!r} is not a valid state value."
+msgstr ""
+
+#: statemachine/exceptions.py:31
+msgid "Can't {} when in {}."
+msgstr ""
+
+#: statemachine/factory.py:35
+msgid ""
+"There should be one and only one initial state. Your currently have "
+"these: {!r}"
+msgstr ""
+
+#: statemachine/factory.py:51
+msgid ""
+"There are unreachable states. The statemachine graph should have a single"
+" component. Disconnected states: {}"
+msgstr ""
+
+#: statemachine/factory.py:69
+msgid "There are no states."
+msgstr ""
+
+#: statemachine/factory.py:72
+msgid "There are no events."
+msgstr ""
+
+#: statemachine/factory.py:82
+msgid "Cannot declare transitions from final state. Invalid state(s): {}"
+msgstr ""
+
+#: statemachine/mixins.py:30
+msgid "{!r} is not a valid state machine name."
+msgstr ""
+
+#: statemachine/state.py:148
+msgid "State overriding is not allowed. Trying to add '{}' to {}"
+msgstr ""
+
+#: statemachine/statemachine.py:48
+msgid "There are no states or transitions."
+msgstr ""

--- a/statemachine/locale/pt_BR/LC_MESSAGES/statemachine.po
+++ b/statemachine/locale/pt_BR/LC_MESSAGES/statemachine.po
@@ -1,0 +1,71 @@
+# This file is distributed under the same license as the PROJECT project.
+# Fernando Macedo <fgmacedo@gmail.com>, 2023.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: 2.0.0\n"
+"Report-Msgid-Bugs-To: fgmacedo@gmail.com\n"
+"POT-Creation-Date: 2023-03-04 16:10-0300\n"
+"PO-Revision-Date: 2023-03-04 16:10-0300\n"
+"Last-Translator: Fernando Macedo <fgmacedo@gmail.com>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
+
+#: statemachine/callbacks.py:56
+msgid "Callback {!r} not property configured."
+msgstr "Callback {!r} não está configurado corretamente."
+
+#: statemachine/dispatcher.py:35
+msgid "Did not found name '{}' from model or statemachine"
+msgstr "Não foi encontrado o nome '{}' no modelo ou na máquina de estados"
+
+#: statemachine/exceptions.py:17
+msgid "{!r} is not a valid state value."
+msgstr "{!r} não é um valor de estado válido."
+
+#: statemachine/exceptions.py:31
+msgid "Can't {} when in {}."
+msgstr "Não é possível {} quando em {}."
+
+#: statemachine/factory.py:35
+msgid ""
+"There should be one and only one initial state. Your currently have "
+"these: {!r}"
+msgstr ""
+"Deve haver um e apenas um estado inicial. Atualmente, você tem "
+"os seguintes: {!r}"
+
+#: statemachine/factory.py:51
+msgid ""
+"There are unreachable states. The statemachine graph should have a single"
+" component. Disconnected states: {}"
+msgstr ""
+"Há estados inalcançáveis. O grafo da máquina de estados deve ter apenas um"
+" componente. Estados desconectados: {}"
+
+#: statemachine/factory.py:69
+msgid "There are no states."
+msgstr "Não há estados."
+
+#: statemachine/factory.py:72
+msgid "There are no events."
+msgstr "Não há eventos."
+
+#: statemachine/factory.py:82
+msgid "Cannot declare transitions from final state. Invalid state(s): {}"
+msgstr "Não é possível declarar transições a partir do estado final. Estado(s) inválido(s): {}"
+
+#: statemachine/mixins.py:30
+msgid "{!r} is not a valid state machine name."
+msgstr "{!r} não é um nome válido para a máquina de estados."
+
+#: statemachine/state.py:148
+msgid "State overriding is not allowed. Trying to add '{}' to {}"
+msgstr "A substituição de estado não é permitida. Tentando adicionar '{}' a {}"
+
+#: statemachine/statemachine.py:48
+msgid "There are no states or transitions."
+msgstr "Não há estados ou transições."

--- a/statemachine/state.py
+++ b/statemachine/state.py
@@ -5,7 +5,7 @@ from .callbacks import Callbacks
 from .exceptions import StateMachineError
 from .transition import Transition
 from .transition_list import TransitionList
-from .utils import ugettext as _
+from .i18n import _
 
 
 class State:

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -13,9 +13,9 @@ from .exceptions import InvalidDefinition
 from .exceptions import InvalidStateValue
 from .exceptions import TransitionNotAllowed
 from .factory import StateMachineMetaclass
+from .i18n import _
 from .model import Model
 from .transition import Transition
-from .utils import ugettext as _
 
 if TYPE_CHECKING:
     from .state import State  # noqa: F401

--- a/statemachine/utils.py
+++ b/statemachine/utils.py
@@ -1,11 +1,3 @@
-try:
-    from django.utils.translation import ugettext
-except Exception:
-
-    def ugettext(text):
-        return text
-
-
 def qualname(cls):
     """
     Returns a fully qualified name of the class, to avoid name collisions.


### PR DESCRIPTION
Add support for internationalization, translating the messages into `pt_BR` as an example.

### Add a translation


Extract a `Portable Object Template` (`POT`) file:

```shell
pybabel extract statemachine -o statemachine/locale/statemachine.pot
```

Then, copy the template as a `.po` file into the target locale folder. For example, if you're adding support for Brazilian Portuguese language, the code is `pt_BR`, and the file path should be `statemachine/locale/pt_BR/LC_MESSAGES/statemachine.po`:

```shell
cp statemachine/locale/statemachine.pot statemachine/locale/pt_BR/LC_MESSAGES/statemachine.po
```

Then open the `statemachine.po` and translate.

After translation, to get the new language working locally, you need to compile the `.po` files into `.mo`  (binary format). Run:

```shell
pybabel compile -d statemachine/locale/ -f statemachine.po
```


On Linux (Debian based), you can test changing the `LANGUAGE` environment variable.

```shell
# If the last line is `Can't guess when in Won.` something went wrong.
LANGUAGE=pt_BR python tests/examples/guess_the_number_machine.py
```

Then open a [pull request](https://github.com/fgmacedo/python-statemachine/pulls) with your translation file.
