### PR TITLE
fix: Transition with multiple events was calling actions of all events

### DIFF
--- a/docs/releases/2.0.0.md
+++ b/docs/releases/2.0.0.md
@@ -185,7 +185,7 @@ Should become:
 >>> from tests.examples.traffic_light_machine import TrafficLightMachine
 
 >>> sm = TrafficLightMachine()
->>> assert [t.name for t in sm.allowed_events] == ["cycle"]
+>>> assert [t.name for t in sm.allowed_events] == ["cycle", "slowdown"]
 
 ```
 

--- a/docs/releases/2.0.0.md
+++ b/docs/releases/2.0.0.md
@@ -131,6 +131,8 @@ See {ref}`Add a translation` on how to contribute with translations.
 
 - [#341](https://github.com/fgmacedo/python-statemachine/issues/341): Fix dynamic dispatch
   on methods with default parameters.
+- [#365](https://github.com/fgmacedo/python-statemachine/pull/365): Fix transition with multiple
+  events was calling actions of all events.
 
 
 ## Backward incompatible changes in 2.0

--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -199,6 +199,7 @@ Or in an event-oriented style, events are `send`:
 
 ```py
 >>> machine.send("cycle")
+Don't move.
 'Running cycle from yellow to red'
 
 >>> machine.current_state.id
@@ -226,6 +227,7 @@ can also raise an exception at this point to stop a transition to occur.
 'red'
 
 >>> machine.cycle()
+Go ahead!
 'Running cycle from red to green'
 
 >>> machine.current_state.id

--- a/statemachine/event.py
+++ b/statemachine/event.py
@@ -58,3 +58,14 @@ def trigger_event_factory(event):
     trigger_event._is_sm_event = True
 
     return trigger_event
+
+
+def same_event_cond_builder(expected_event: str):
+    """
+    Builds a condition method that evaluates to ``True`` when the expected event is received.
+    """
+
+    def cond(event: str) -> bool:
+        return event == expected_event
+
+    return cond

--- a/statemachine/transition.py
+++ b/statemachine/transition.py
@@ -3,18 +3,12 @@ from typing import TYPE_CHECKING
 
 from .callbacks import Callbacks
 from .callbacks import ConditionWrapper
+from .event import same_event_cond_builder
 from .events import Events
 from .exceptions import InvalidDefinition
 
 if TYPE_CHECKING:
     from .event_data import EventData
-
-
-def same_event_cond_builder(expected_event: str):
-    def cond(event: str) -> bool:
-        return event == expected_event
-
-    return cond
 
 
 class Transition:

--- a/tests/examples/traffic_light_machine.py
+++ b/tests/examples/traffic_light_machine.py
@@ -1,8 +1,24 @@
 """
-Traffic light machine
----------------------
 
-Demonstrates the concept of ``cycle`` states.
+-------------------
+Reusing transitions
+-------------------
+
+This example helps to turn visual the different compositions of how to declare
+and bind :ref:`transitions` to :ref:`event`.
+
+.. note::
+
+    Even sharing the same transition instance, only the transition actions associated with the
+    event will be called.
+
+
+TrafficLightMachine
+   The same transitions are bound to more than one event.
+
+TrafficLightIsolatedTransitions
+    We define new transitions, thus, isolating the connection
+    between states.
 
 """
 from statemachine import State
@@ -15,7 +31,64 @@ class TrafficLightMachine(StateMachine):
     yellow = State()
     red = State()
 
+    slowdown = green.to(yellow)
+    stop = yellow.to(red)
+    go = red.to(green)
+
+    cycle = slowdown | stop | go
+
+    def before_slowdown(self):
+        print("Slowdown")
+
+    def before_cycle(self, event: str, source: State, target: State, message: str = ""):
+        message = ". " + message if message else ""
+        return f"Running {event} from {source.id} to {target.id}{message}"
+
+    def on_enter_red(self):
+        print("Don't move.")
+
+    def on_exit_red(self):
+        print("Go ahead!")
+
+
+# %%
+# Run a transition
+
+sm = TrafficLightMachine()
+sm.send("cycle")
+
+
+# %%
+
+
+class TrafficLightIsolatedTransitions(StateMachine):
+    "A traffic light machine"
+    green = State(initial=True)
+    yellow = State()
+    red = State()
+
+    slowdown = green.to(yellow)
+    stop = yellow.to(red)
+    go = red.to(green)
+
     cycle = green.to(yellow) | yellow.to(red) | red.to(green)
 
-    def on_cycle(self, event_data):
-        return f"Running {event_data.event} from {event_data.source.id} to {event_data.target.id}"
+    def before_slowdown(self):
+        print("Slowdown")
+
+    def before_cycle(self, event: str, source: State, target: State, message: str = ""):
+        message = ". " + message if message else ""
+        return f"Running {event} from {source.id} to {target.id}{message}"
+
+    def on_enter_red(self):
+        print("Don't move.")
+
+    def on_exit_red(self):
+        print("Go ahead!")
+
+
+# %%
+# Run a transition
+
+sm2 = TrafficLightIsolatedTransitions()
+sm2.send("cycle")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -13,7 +13,8 @@ def test_assign_events_on_transitions():
         yellow.to(red, event="cycle stop")
         red.to(green, event="cycle go")
 
-        def on_cycle(self, event_data, event: str = ""):
+        def on_cycle(self, event_data, event: str):
+            assert event_data.event == event
             return (
                 f"Running {event} from {event_data.transition.source.id} to "
                 f"{event_data.transition.target.id}"

--- a/tests/testcases/issue308.md
+++ b/tests/testcases/issue308.md
@@ -1,9 +1,9 @@
 ### Issue 308
 
-A StateMachine that exercices the example given on issue
+A StateMachine that exercises the example given on issue
 #[308](https://github.com/fgmacedo/python-statemachine/issues/308).
 
-On this example, we share the transitions list between events.
+In this example, we share the transition list between events.
 
 ```py
 >>> from statemachine import StateMachine, State
@@ -14,12 +14,12 @@ On this example, we share the transitions list between events.
 ...     state3 = State('s3')
 ...     state4 = State('s4', final=True)
 ...
-...     trans12 = state1.to(state2)
-...     trans23 = state2.to(state3)
-...     trans34 = state3.to(state4)
+...     event1 = state1.to(state2)
+...     event2 = state2.to(state3)
+...     event3 = state3.to(state4)
 ...
 ...     # cycle = state1.to(state2) | state2.to(state3) | state3.to(state4)
-...     cycle = trans12 | trans23 | trans34
+...     cycle = event1 | event2 | event3
 ...
 ...     def before_cycle(self):
 ...         print("before cycle")
@@ -55,31 +55,31 @@ On this example, we share the transitions list between events.
 ...         print('exit state4')
 ...
 ...     def before_trans12(self):
-...         print('before trans12')
+...         print('before event1')
 ...
 ...     def on_trans12(self):
-...         print('on trans12')
+...         print('on event1')
 ...
 ...     def after_trans12(self):
-...         print('after trans12')
+...         print('after event1')
 ...
 ...     def before_trans23(self):
-...         print('before trans23')
+...         print('before event2')
 ...
 ...     def on_trans23(self):
-...         print('on trans23')
+...         print('on event2')
 ...
 ...     def after_trans23(self):
-...         print('after trans23')
+...         print('after event2')
 ...
 ...     def before_trans34(self):
-...         print('before trans34')
+...         print('before event3')
 ...
 ...     def on_trans34(self):
-...         print('on trans34')
+...         print('on event3')
 ...
 ...     def after_trans34(self):
-...         print('after trans34')
+...         print('after event3')
 ...
 
 ```
@@ -94,35 +94,26 @@ enter state1
 >>> m.state1.is_active, m.state2.is_active, m.state3.is_active, m.state4.is_active, m.current_state ; _ = m.cycle()
 (True, False, False, False, State('s1', id='state1', value='state1', initial=True, final=False))
 before cycle
-before trans12
 exit state1
 on cycle
-on trans12
 enter state2
 after cycle
-after trans12
 
 >>> m.state1.is_active, m.state2.is_active, m.state3.is_active, m.state4.is_active, m.current_state ; _ = m.cycle()
 (False, True, False, False, State('s2', id='state2', value='state2', initial=False, final=False))
 before cycle
-before trans23
 exit state2
 on cycle
-on trans23
 enter state3
 after cycle
-after trans23
 
 >>> m.state1.is_active, m.state2.is_active, m.state3.is_active, m.state4.is_active, m.current_state ; _ = m.cycle()
 (False, False, True, False, State('s3', id='state3', value='state3', initial=False, final=False))
 before cycle
-before trans34
 exit state3
 on cycle
-on trans34
 enter state4
 after cycle
-after trans34
 
 >>> m.state1.is_active, m.state2.is_active, m.state3.is_active, m.state4.is_active, m.current_state
 (False, False, False, True, State('s4', id='state4', value='state4', initial=False, final=True))


### PR DESCRIPTION
Given this state machine:

```py
from statemachine import State
from statemachine import StateMachine


class TrafficLightMachine(StateMachine):
    "A traffic light machine"
    green = State(initial=True)
    yellow = State()
    red = State()

    slowdown = green.to(yellow)
    stop = yellow.to(red)
    go = red.to(green)

    cycle = slowdown | stop | go

    def before_slowdown(self):
        print("Slowdown")

    def before_cycle(self, event: str, source: State, target: State):
        return f"Running {event} from {source.id} to {target.id}"
```

Note that the state machine definition is sharing the same instance of transitions between two events. Like this:

![image](https://user-images.githubusercontent.com/281007/222985045-332bf7d4-78e9-462d-9941-949236a23c47.png)

Running this SM without the fix, when sending the event `cycle`, the `slowdown` action was also called:

```python
>>> sm = TrafficLightMachine()
>>> sm.send("cycle")
'Slowdown'
['Running cycle from green to yellow', None]
```


With the fix:

```python
>>> sm = TrafficLightMachine()
>>> sm.send("cycle")
'Running cycle from green to yellow'
```