### PR TITLE
fix: Add support for wrapping functools.partial. Closes #369

### DIFF
--- a/docs/releases/2.0.1.md
+++ b/docs/releases/2.0.1.md
@@ -1,0 +1,12 @@
+# StateMachine 2.0.1
+
+*Not released yet*
+
+
+StateMachine 2.0.1 is a bugfix release.
+
+
+## Bugfixes
+
+- Fixes [#369](https://github.com/fgmacedo/python-statemachine/issues/336) adding support to wrap
+  methods used as {ref}`Actions` decorated with `functools.partial`.

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -15,6 +15,7 @@ Below are release notes through StateMachine and its patch releases.
 ```{toctree}
 :maxdepth: 1
 
+2.0.1
 2.0.0
 
 ```

--- a/statemachine/signature.py
+++ b/statemachine/signature.py
@@ -1,10 +1,10 @@
 import itertools
-from collections.abc import Callable
 from functools import partial
 from inspect import BoundArguments
 from inspect import Parameter
 from inspect import Signature
 from typing import Any
+from typing import Callable
 
 
 class SignatureAdapter(Signature):

--- a/statemachine/signature.py
+++ b/statemachine/signature.py
@@ -1,9 +1,10 @@
 import itertools
+from collections.abc import Callable
+from functools import partial
 from inspect import BoundArguments
 from inspect import Parameter
 from inspect import Signature
 from typing import Any
-from typing import Callable
 
 
 class SignatureAdapter(Signature):
@@ -15,7 +16,9 @@ class SignatureAdapter(Signature):
 
         sig = cls.from_callable(method)
         sig.method = method
-        sig.__name__ = method.__name__
+        sig.__name__ = (
+            method.func.__name__ if isinstance(method, partial) else method.__name__
+        )
         return sig
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,4 +1,5 @@
 import inspect
+from functools import partial
 
 import pytest
 
@@ -148,9 +149,17 @@ class TestSignatureAdapter:
     def test_wrap_fn_single_positional_parameter(self, func, args, kwargs, expected):
 
         wrapped_func = SignatureAdapter.wrap(func)
+        assert wrapped_func.__name__ == func.__name__
 
         if inspect.isclass(expected) and issubclass(expected, Exception):
             with pytest.raises(expected):
                 wrapped_func(*args, **kwargs)
         else:
             assert wrapped_func(*args, **kwargs) == expected
+
+    def test_support_for_partial(self):
+        part = partial(positional_and_kw_arguments, event="activated")
+        wrapped_func = SignatureAdapter.wrap(part)
+
+        assert wrapped_func("A", "B") == ("A", "B", "activated")
+        assert wrapped_func.__name__ == positional_and_kw_arguments.__name__


### PR DESCRIPTION
Add support for wrapping functools.partial. Closes #369.