### PR TITLE
fix: Multiple observers can watch the same callback

### DIFF
--- a/docs/releases/2.1.0.md
+++ b/docs/releases/2.1.0.md
@@ -40,3 +40,4 @@ See {ref}`States from Enum types`.
 
 - Fixes [#369](https://github.com/fgmacedo/python-statemachine/issues/369) adding support to wrap
   methods used as {ref}`Actions` decorated with `functools.partial`.
+- Fixes [#384](https://github.com/fgmacedo/python-statemachine/issues/384) so multiple observers can watch the same callback.

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -112,3 +112,13 @@ class TestResolverFactory:
         resolver = resolver_factory(org_config, person)
         resolved_method = resolver(attr)
         assert resolved_method() == expected_value
+
+    def test_should_generate_unique_ids(self):
+        person = Person("Frodo", "Bolseiro", "cpf")
+        org = Organization("The Lord fo the Rings", "cnpj")
+
+        resolver1 = resolver_factory(org, person)
+        resolver2 = resolver_factory(org, person)
+        resolver3 = resolver_factory(org, person)
+
+        assert resolver1.id == resolver2.id == resolver3.id

--- a/tests/testcases/issue384_multiple_observers.md
+++ b/tests/testcases/issue384_multiple_observers.md
@@ -1,0 +1,57 @@
+### Issue 384
+
+A StateMachine that exercises the example given on issue
+#[384](https://github.com/fgmacedo/python-statemachine/issues/384).
+
+In this example, we register multiple observers to the same named callback.
+
+This works also as a regression test.
+
+```py
+>>> from statemachine import State
+>>> from statemachine import StateMachine
+
+>>> class MyObs:
+...     def on_move_car(self):
+...         print("I observed moving from 1")
+
+>>> class MyObs2:
+...     def on_move_car(self):
+...         print("I observed moving from 2")
+...
+
+
+>>> class Car(StateMachine):
+...     stopped = State(initial=True)
+...     moving = State()
+...
+...     move_car = stopped.to(moving)
+...     stop_car = moving.to(stopped)
+...
+...     def on_move_car(self):
+...         print("I'm moving")
+
+```
+
+Running:
+
+```py
+>>> car = Car()
+>>> obs = MyObs()
+>>> obs2 = MyObs2()
+>>> car.add_observer(obs)
+Car(model=Model(state=stopped), state_field='state', current_state='stopped')
+
+>>> car.add_observer(obs2)
+Car(model=Model(state=stopped), state_field='state', current_state='stopped')
+
+>>> car.add_observer(obs2)  # test to not register duplicated observer callbacks
+Car(model=Model(state=stopped), state_field='state', current_state='stopped')
+
+>>> car.move_car()
+I'm moving
+I observed moving from 1
+I observed moving from 2
+[None, None, None]
+
+```


### PR DESCRIPTION
Fixes #384 .

#### Multiple observers now can watch the same callback
we register multiple observers to the same named callback.

This works also as a regression test.

```py
>>> from statemachine import State
>>> from statemachine import StateMachine

>>> class MyObs:
...     def on_move_car(self):
...         print("I observed moving from 1")

>>> class MyObs2:
...     def on_move_car(self):
...         print("I observed moving from 2")
...


>>> class Car(StateMachine):
...     stopped = State(initial=True)
...     moving = State()
...
...     move_car = stopped.to(moving)
...     stop_car = moving.to(stopped)
...
...     def on_move_car(self):
...         print("I'm moving")

```

Running:

```py
>>> car = Car()
>>> obs = MyObs()
>>> obs2 = MyObs2()
>>> car.add_observer(obs)
Car(model=Model(state=stopped), state_field='state', current_state='stopped')

>>> car.add_observer(obs2)
Car(model=Model(state=stopped), state_field='state', current_state='stopped')

>>> car.add_observer(obs2)  # test to not register duplicated observer callbacks
Car(model=Model(state=stopped), state_field='state', current_state='stopped')

>>> car.move_car()
I'm moving
I observed moving from 1
I observed moving from 2
[None, None, None]

```