### PR TITLE
fix: Add support for pytest-mock spy method fixing the SignatureAdapter

### DIFF
--- a/docs/releases/2.1.1.md
+++ b/docs/releases/2.1.1.md
@@ -1,0 +1,8 @@
+# StateMachine 2.1.1
+
+*Not released yet*
+
+## Bugfixes in 2.1.1
+
+- Fixes [#391](https://github.com/fgmacedo/python-statemachine/issues/391) adding support to
+  [pytest-mock](https://pytest-mock.readthedocs.io/en/latest/index.html) `spy` method.

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -15,6 +15,7 @@ Below are release notes through StateMachine and its patch releases.
 ```{toctree}
 :maxdepth: 1
 
+2.1.1
 2.1.0
 2.0.0
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -972,6 +972,24 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.10.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-mock-3.10.0.tar.gz", hash = "sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f"},
+    {file = "pytest_mock-3.10.0-py3-none-any.whl", hash = "sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b"},
+]
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "pytest-sugar"
 version = "0.9.7"
 description = "pytest-sugar is a plugin for pytest that changes the default look and feel of pytest (e.g. progressbar, show tests that fail instantly)."
@@ -1495,4 +1513,4 @@ diagrams = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7, <3.12"
-content-hash = "1a2ce5412b6332aebdd5068efed3e098593ebaaf9b2a0fa2437f3f0ee84b82c6"
+content-hash = "b0b43742909aa984bdf9fd4edb93d8e8143ca09aaff3d9aa7110eeb8902c3b55"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ pre-commit = "^2.21.0"
 mypy = "^0.991"
 black = "^22.12.0"
 pdbpp = "^0.10.3"
+pytest-mock = "^3.10.0"
 
 [tool.poetry.group.docs.dependencies]
 Sphinx = "4.5.0"

--- a/statemachine/signature.py
+++ b/statemachine/signature.py
@@ -25,6 +25,16 @@ class SignatureAdapter(Signature):
         ba = self.bind_expected(*args, **kwargs)
         return self.method(*ba.args, **ba.kwargs)
 
+    @classmethod
+    def from_callable(cls, method):
+        if hasattr(method, "__signature__"):
+            sig = method.__signature__
+            return SignatureAdapter(
+                sig.parameters.values(),
+                return_annotation=sig.return_annotation,
+            )
+        return super().from_callable(method)
+
     def bind_expected(self, *args: Any, **kwargs: Any) -> BoundArguments:  # noqa: C901
         """Get a BoundArguments object, that maps the passed `args`
         and `kwargs` to the function's signature.  It avoids to raise `TypeError`

--- a/tests/test_mock_compatibility.py
+++ b/tests/test_mock_compatibility.py
@@ -1,0 +1,25 @@
+from statemachine import State
+from statemachine import StateMachine
+
+
+def test_minimal(mocker):
+    class Observer:
+        def on_enter_state(self, event, model, source, target, state):
+            ...
+
+    obs = Observer()
+    on_enter_state = mocker.spy(obs, "on_enter_state")
+
+    class Machine(StateMachine):
+        a = State("Init", initial=True)
+        b = State("Fin")
+
+        cycle = a.to(b) | b.to(a)
+
+    state = Machine().add_observer(obs)
+    assert state.a.is_active
+
+    state.cycle()
+
+    assert state.b.is_active
+    on_enter_state.assert_called_once()


### PR DESCRIPTION
Fixes #391 .

Changed `SignatureAdapter` class to fix a bug where `cls.from_callable(method)` would return a `Signature` object instead of a `SignatureAdapter` if the method already had a `Signature`. Ensures that `cls.from_callable(method)` always returns a `SignatureAdapter`.