### PR TITLE
Check for trap states and states that can't reach a final state

### DIFF
--- a/docs/states.md
+++ b/docs/states.md
@@ -21,6 +21,55 @@ A {ref}`StateMachine` should have one and only one `initial` {ref}`state`.
 The initial {ref}`state` is entered when the machine starts and the corresponding entering
 state {ref}`actions` are called if defined.
 
+## State Transitions
+
+All states should have at least one transition to and from another state.
+
+If any states are unreachable from the initial state, an `InvalidDefinition` exception will be thrown.
+
+```py
+>>> class TrafficLightMachine(StateMachine):
+...     "A workflow machine"
+...     red = State('Red', initial=True, value=1)
+...     green = State('Green', value=2)
+...     orange = State('Orange', value=3)
+...     hazard = State('Hazard', value=4)
+...
+...     cycle = red.to(green) | green.to(orange) | orange.to(red)
+...     blink = hazard.to.itself()
+
+Traceback (most recent call last):
+...
+InvalidDefinition: There are unreachable states. The statemachine graph should have a single component. Disconnected states: ['hazard']
+```
+
+`StateMachine` will also check that all non-final states have an outgoing transition, and warn you if any states would result in
+the statemachine becoming trapped in a non-final state with no further transitions possible.
+
+```{note}
+This will currently issue a warning, but can be turned into an exception by setting `strict_states=True` on the class.
+```
+
+```py
+>>> class TrafficLightMachine(StateMachine, strict_states=True):
+...     "A workflow machine"
+...     red = State('Red', initial=True, value=1)
+...     green = State('Green', value=2)
+...     orange = State('Orange', value=3)
+...     hazard = State('Hazard', value=4)
+...
+...     cycle = red.to(green) | green.to(orange) | orange.to(red)
+...     fault = red.to(hazard) | green.to(hazard) | orange.to(hazard)
+
+Traceback (most recent call last):
+...
+InvalidDefinition: All non-final states should have at least one outgoing transition. These states have no outgoing transition: ['hazard']
+```
+
+```{warning}
+`strict_states=True` will become the default behaviour in future versions.
+```
+
 
 (final-state)=
 ## Final state
@@ -41,13 +90,42 @@ Transitions from these states are not allowed and will raise exceptions.
 ...     add_job = draft.to.itself() | producing.to.itself() | closed.to(producing)
 ...     produce = draft.to(producing)
 ...     deliver = producing.to(closed)
+
 Traceback (most recent call last):
 ...
 InvalidDefinition: Cannot declare transitions from final state. Invalid state(s): ['closed']
 
 ```
 
-You can retrieve all final states.
+If you mark any states as final, `StateMachine` will check that all non-final states have a path to reach at least one final state.
+
+```{note}
+This will currently issue a warning, but can be turned into an exception by setting `strict_states=True` on the class.
+```
+
+```py
+>>> class CampaignMachine(StateMachine, strict_states=True):
+...     "A workflow machine"
+...     draft = State('Draft', initial=True, value=1)
+...     producing = State('Being produced', value=2)
+...     abandoned = State('Abandoned', value=3)
+...     closed = State('Closed', final=True, value=4)
+...
+...     add_job = draft.to.itself() | producing.to.itself()
+...     produce = draft.to(producing)
+...     abandon = producing.to(abandoned)
+...     deliver = producing.to(closed)
+
+Traceback (most recent call last):
+...
+InvalidDefinition: All non-final states should have at least one path to a final state. These states have no path to a final state: ['abandoned']
+```
+
+```{warning}
+`strict_states=True` will become the default behaviour in future versions.
+```
+
+You can query a list of all final states from your statemachine.
 
 ```py
 >>> class CampaignMachine(StateMachine):
@@ -64,6 +142,9 @@ You can retrieve all final states.
 
 >>> machine.final_states
 [State('Closed', id='closed', value=3, initial=False, final=True)]
+
+>>> machine.current_state in machine.final_states
+False
 
 ```
 

--- a/docs/states.md
+++ b/docs/states.md
@@ -39,7 +39,6 @@ If any states are unreachable from the initial state, an `InvalidDefinition` exc
 ...
 ...     cycle = red.to(green) | green.to(orange) | orange.to(red)
 ...     blink = hazard.to.itself()
-
 Traceback (most recent call last):
 ...
 InvalidDefinition: There are unreachable states. The statemachine graph should have a single component. Disconnected states: ['hazard']
@@ -64,7 +63,6 @@ This will currently issue a warning, but can be turned into an exception by sett
 ...
 ...     cycle = red.to(green) | green.to(orange) | orange.to(red)
 ...     fault = red.to(hazard) | green.to(hazard) | orange.to(hazard)
-
 Traceback (most recent call last):
 ...
 InvalidDefinition: All non-final states should have at least one outgoing transition. These states have no outgoing transition: ['hazard']
@@ -94,7 +92,6 @@ Transitions from these states are not allowed and will raise exceptions.
 ...     add_job = draft.to.itself() | producing.to.itself() | closed.to(producing)
 ...     produce = draft.to(producing)
 ...     deliver = producing.to(closed)
-
 Traceback (most recent call last):
 ...
 InvalidDefinition: Cannot declare transitions from final state. Invalid state(s): ['closed']
@@ -119,10 +116,10 @@ This will currently issue a warning, but can be turned into an exception by sett
 ...     produce = draft.to(producing)
 ...     abandon = producing.to(abandoned) | abandoned.to(abandoned)
 ...     deliver = producing.to(closed)
-
 Traceback (most recent call last):
 ...
 InvalidDefinition: All non-final states should have at least one path to a final state. These states have no path to a final state: ['abandoned']
+
 ```
 
 ```{warning}

--- a/docs/states.md
+++ b/docs/states.md
@@ -28,6 +28,8 @@ All states should have at least one transition to and from another state.
 If any states are unreachable from the initial state, an `InvalidDefinition` exception will be thrown.
 
 ```py
+>>> from statemachine import StateMachine, State
+
 >>> class TrafficLightMachine(StateMachine):
 ...     "A workflow machine"
 ...     red = State('Red', initial=True, value=1)
@@ -51,6 +53,8 @@ This will currently issue a warning, but can be turned into an exception by sett
 ```
 
 ```py
+>>> from statemachine import StateMachine, State
+
 >>> class TrafficLightMachine(StateMachine, strict_states=True):
 ...     "A workflow machine"
 ...     red = State('Red', initial=True, value=1)
@@ -113,7 +117,7 @@ This will currently issue a warning, but can be turned into an exception by sett
 ...
 ...     add_job = draft.to.itself() | producing.to.itself()
 ...     produce = draft.to(producing)
-...     abandon = producing.to(abandoned)
+...     abandon = producing.to(abandoned) | abandoned.to(abandoned)
 ...     deliver = producing.to(closed)
 
 Traceback (most recent call last):

--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -219,8 +219,8 @@ an action that `echoes` back the parameters informed.
 ```
 
 
-This action is executed before the transition associated with `cycle` event is activated, so you
-can also raise an exception at this point to stop a transition to occur.
+This action is executed before the transition associated with `cycle` event is activated.
+You can raise an exception at this point to stop a transition from completing.
 
 ```py
 >>> machine.current_state.id

--- a/statemachine/factory.py
+++ b/statemachine/factory.py
@@ -22,7 +22,11 @@ class StateMachineMetaclass(type):
     "Metaclass for constructing StateMachine classes"
 
     def __init__(
-        cls, name: str, bases: Tuple[type], attrs: Dict[str, Any], strict_states: bool = False
+        cls,
+        name: str,
+        bases: Tuple[type],
+        attrs: Dict[str, Any],
+        strict_states: bool = False,
     ) -> None:
         super().__init__(name, bases, attrs)
         registry.register(cls)
@@ -125,8 +129,10 @@ class StateMachineMetaclass(type):
 
     def _states_without_path_to_final_states(cls):
         return [
-            state for state in cls.states
-            if not state.final and not any(s.final for s in visit_connected_states(state))
+            state
+            for state in cls.states
+            if not state.final
+            and not any(s.final for s in visit_connected_states(state))
         ]
 
     def _disconnected_states(cls, starting_state):

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -84,7 +84,6 @@ class StateMachine(metaclass=StateMachineMetaclass):
         self._setup(initial_transition)
         self._activate_initial_state(initial_transition)
 
-
     def __init_subclass__(cls, strict_states: bool = False):
         cls._strict_states = strict_states
         super().__init_subclass__()

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -84,6 +84,11 @@ class StateMachine(metaclass=StateMachineMetaclass):
         self._setup(initial_transition)
         self._activate_initial_state(initial_transition)
 
+
+    def __init_subclass__(cls, strict_states: bool = False):
+        cls._strict_states = strict_states
+        super().__init_subclass__()
+
     if TYPE_CHECKING:
         """Makes mypy happy with dynamic created attributes"""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def campaign_machine():
         "A workflow machine"
         draft = State(initial=True)
         producing = State("Being produced")
-        closed = State()
+        closed = State(final=True)
 
         add_job = draft.to(draft) | producing.to(producing)
         produce = draft.to(producing)
@@ -42,7 +42,7 @@ def campaign_machine_with_validator():
         "A workflow machine"
         draft = State(initial=True)
         producing = State("Being produced")
-        closed = State()
+        closed = State(final=True)
 
         add_job = draft.to(draft) | producing.to(producing)
         produce = draft.to(producing, validators="can_produce")
@@ -84,7 +84,7 @@ def campaign_machine_with_values():
         "A workflow machine"
         draft = State(initial=True, value=1)
         producing = State("Being produced", value=2)
-        closed = State(value=3)
+        closed = State(value=3, final=True)
 
         add_job = draft.to(draft) | producing.to(producing)
         produce = draft.to(producing)
@@ -164,7 +164,7 @@ def approval_machine(current_time):  # noqa: C901
         accepted = State()
         rejected = State()
 
-        completed = State()
+        completed = State(final=True)
 
         validate = requested.to(accepted, cond="is_ok") | requested.to(rejected)
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -184,7 +184,7 @@ class TestCallbacksAsDecorator:
         assert race_uppercase("Hobbit") == "HOBBIT"
 
     def test_decorate_unbounded_machine_methods(self):
-        class MiniHeroJourneyMachine(StateMachine):
+        class MiniHeroJourneyMachine(StateMachine, strict_states=False):
 
             ordinary_world = State(initial=True)
             call_to_adventure = State()

--- a/tests/test_multiple_destinations.py
+++ b/tests/test_multiple_destinations.py
@@ -52,8 +52,8 @@ def test_transition_to_first_that_executes_if_multiple_targets():
     class ApprovalMachine(StateMachine):
         "A workflow"
         requested = State(initial=True)
-        accepted = State()
-        rejected = State()
+        accepted = State(final=True)
+        rejected = State(final=True)
 
         validate = requested.to(accepted, rejected)
 
@@ -70,8 +70,8 @@ def test_do_not_transition_if_multiple_targets_with_guard():
     class ApprovalMachine(StateMachine):
         "A workflow"
         requested = State(initial=True)
-        accepted = State()
-        rejected = State()
+        accepted = State(final=True)
+        rejected = State(final=True)
 
         validate = (
             requested.to(accepted, cond=never_will_pass)
@@ -97,8 +97,8 @@ def test_check_invalid_reference_to_conditions():
     class ApprovalMachine(StateMachine):
         "A workflow"
         requested = State(initial=True)
-        accepted = State()
-        rejected = State()
+        accepted = State(final=True)
+        rejected = State(final=True)
 
         validate = requested.to(accepted, cond="not_found_condition") | requested.to(
             rejected
@@ -114,7 +114,7 @@ def test_should_change_to_returned_state_on_multiple_target_with_combined_transi
         requested = State(initial=True)
         accepted = State()
         rejected = State()
-        completed = State()
+        completed = State(final=True)
 
         validate = (
             requested.to(accepted, cond="is_ok")
@@ -179,8 +179,8 @@ def test_multiple_values_returned_with_multiple_targets():
     class ApprovalMachine(StateMachine):
         "A workflow"
         requested = State(initial=True)
-        accepted = State()
-        denied = State()
+        accepted = State(final=True)
+        denied = State(final=True)
 
         @requested.to(accepted, denied)
         def validate(self):
@@ -206,7 +206,7 @@ def test_multiple_targets_using_or_starting_from_same_origin(
 ):
     class InvoiceStateMachine(StateMachine):
         unpaid = State(initial=True)
-        paid = State()
+        paid = State(final=True)
         failed = State()
 
         pay = (

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -13,7 +13,7 @@ def chained_after_sm_class():  # noqa: C901
     class ChainedSM(StateMachine):
         a = State(initial=True)
         b = State()
-        c = State()
+        c = State(final=True)
 
         t1 = a.to(b, after="t1") | b.to(c)
 
@@ -52,7 +52,7 @@ def chained_on_sm_class():  # noqa: C901
         s1 = State(initial=True)
         s2 = State()
         s3 = State()
-        s4 = State()
+        s4 = State(final=True)
 
         t1 = s1.to(s2)
         t2a = s2.to(s2)

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -54,7 +54,7 @@ def test_machine_should_activate_initial_state():
     class CampaignMachine(StateMachine):
         "A workflow machine"
         producing = State()
-        closed = State()
+        closed = State(final=True)
         draft = State(initial=True)
 
         add_job = draft.to(draft) | producing.to(producing)
@@ -381,7 +381,7 @@ def test_state_value_is_correct():
     STATE_NEW = 0
     STATE_DRAFT = 1
 
-    class ValueTestModel(StateMachine):
+    class ValueTestModel(StateMachine, strict_states=False):
         new = State(STATE_NEW, value=STATE_NEW, initial=True)
         draft = State(STATE_DRAFT, value=STATE_DRAFT)
 

--- a/tests/test_statemachine_bounded_transitions.py
+++ b/tests/test_statemachine_bounded_transitions.py
@@ -18,7 +18,7 @@ def state_machine(event_mock):
     class CampaignMachine(StateMachine):
         draft = State(initial=True)
         producing = State()
-        closed = State()
+        closed = State(final=True)
 
         add_job = draft.to(draft) | producing.to(producing)
         produce = draft.to(producing)

--- a/tests/test_statemachine_inheritance.py
+++ b/tests/test_statemachine_inheritance.py
@@ -8,7 +8,7 @@ def BaseMachine():
     from statemachine import State
     from statemachine import StateMachine
 
-    class BaseMachine(StateMachine):
+    class BaseMachine(StateMachine, strict_states=False):
         state_1 = State(initial=True)
         state_2 = State()
         trans_1_2 = state_1.to(state_2)
@@ -18,7 +18,7 @@ def BaseMachine():
 
 @pytest.fixture()
 def InheritedClass(BaseMachine):
-    class InheritedClass(BaseMachine):
+    class InheritedClass(BaseMachine, strict_states=False):
         pass
 
     return InheritedClass
@@ -29,7 +29,7 @@ def ExtendedClass(BaseMachine):
     from statemachine import State
 
     class ExtendedClass(BaseMachine):
-        state_3 = State()
+        state_3 = State(final=True)
         trans_2_3 = BaseMachine.state_2.to(state_3)
 
     return ExtendedClass
@@ -40,7 +40,7 @@ def OverridedClass(BaseMachine):
     from statemachine import State
 
     class OverridedClass(BaseMachine):
-        state_2 = State()
+        state_2 = State(final=True)
 
         trans_1_2 = BaseMachine.state_1.to(state_2)
 
@@ -52,7 +52,7 @@ def OverridedTransitionClass(BaseMachine):
     from statemachine import State
 
     class OverridedTransitionClass(BaseMachine):
-        state_3 = State()
+        state_3 = State(final=True)
         trans_1_2 = BaseMachine.state_1.to(state_3)
 
     return OverridedTransitionClass

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -77,7 +77,7 @@ def transition_callback_machine(request):
         class ApprovalMachine(StateMachine):
             "A workflow"
             requested = State(initial=True)
-            accepted = State()
+            accepted = State(final=True)
 
             validate = requested.to(accepted)
 
@@ -90,7 +90,7 @@ def transition_callback_machine(request):
         class ApprovalMachine(StateMachine):
             "A workflow"
             requested = State(initial=True)
-            accepted = State()
+            accepted = State(final=True)
 
             @requested.to(accepted)
             def validate(self):
@@ -175,8 +175,8 @@ def test_should_transition_with_a_dict_as_return():
     class ApprovalMachine(StateMachine):
         "A workflow"
         requested = State(initial=True)
-        accepted = State()
-        rejected = State()
+        accepted = State(final=True)
+        rejected = State(final=True)
 
         accept = requested.to(accepted)
         reject = requested.to(rejected)

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -164,6 +164,7 @@ def test_can_detect_unreachable_final_states():
             produce = draft.to(producing)
             pause = producing.to(paused) | paused.to.itself()
 
+
 def test_transitions_to_the_same_estate_as_itself():
     class CampaignMachine(StateMachine):
         "A workflow machine"

--- a/tests/testcases/issue406.md
+++ b/tests/testcases/issue406.md
@@ -9,7 +9,7 @@ In this example, the event callback must be registered only once.
 >>> from statemachine import State
 >>> from statemachine import StateMachine
 
->>> class ExampleStateMachine(StateMachine):
+>>> class ExampleStateMachine(StateMachine, strict_states=False):
 ...     Created = State(initial=True)
 ...     Inited = State()
 ...


### PR DESCRIPTION
Implements ideas in #408, by adding checks for states with no outgoing transitions (`_check_trap_states`) and states that have no path to a final state, if final states exist (`_check_reachable_final_states`).

It will generate a warning if `strict_states=False`, and an an exception if `strict_states=True`. The current default is False, but i have updated all the tests to pass with the default set to True.

This is a first pass at the code, please give me some feedback before i start writing up the documentation.