### PR TITLE
Fixes issue 443

### DIFF
--- a/statemachine/utils.py
+++ b/statemachine/utils.py
@@ -29,5 +29,5 @@ def run_async_from_sync(coroutine):
         loop = asyncio.get_running_loop()
         return asyncio.ensure_future(coroutine)
     except RuntimeError:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
         return loop.run_until_complete(coroutine)

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -417,3 +417,30 @@ def test_should_not_override_states_properties(campaign_machine):
         machine.draft = "something else"
 
     assert "State overriding is not allowed. Trying to add 'something else' to draft" in str(e)
+
+
+def test_machine_should_allow_multi_thread_event_changes():
+    """
+        Test for https://github.com/fgmacedo/python-statemachine/issues/443
+    """
+    import threading, time
+    class CampaignMachine(StateMachine):
+        "A workflow machine"
+
+        draft = State(initial=True)
+        producing = State()
+        closed = State()
+        add_job = draft.to(producing) | producing.to(closed)
+
+    machine = CampaignMachine()
+    def off_thread_change_state():
+        time.sleep(0.01)
+        machine.add_job()
+    thread = threading.Thread(target=off_thread_change_state)
+    thread.start()
+    thread.join()
+    assert machine.current_state.id == "producing"
+
+
+
+


### PR DESCRIPTION
https://github.com/fgmacedo/python-statemachine/issues/443

Uses `new_event_loop` call when there is no running asyncio event_loop, instead of deprecated `get_event_loop`.