### PR TITLE
Fix regression that did not trigger events in nested calls within an already running transition

### DIFF
--- a/docs/processing_model.md
+++ b/docs/processing_model.md
@@ -91,6 +91,10 @@ Note that the events `connect` and `connection_succeed` are executed sequentiall
 
 ## Non-RTC model
 
+```{deprecated} 2.3.2
+`StateMachine.rtc` option is deprecated. We'll keep only the **run-to-completion** (RTC) model.
+```
+
 In contrast, in a non-RTC (synchronous) processing model, the state machine starts executing nested events
 while processing a parent event. This means that when an event is triggered, the state machine
 chains the processing when another event was triggered as a result of the first event.

--- a/docs/releases/1.0.1.md
+++ b/docs/releases/1.0.1.md
@@ -217,7 +217,7 @@ single `Transition`.
 
 ## Deprecated features in 1.0
 
-### Statemachine class
+### Statemachine class deprecations
 
 - `StateMachine.run` is deprecated in favor of `StateMachine.send`.
 - `StateMachine.allowed_transitions` is deprecated in favor of `StateMachine.allowed_events`.

--- a/docs/releases/2.3.2.md
+++ b/docs/releases/2.3.2.md
@@ -43,10 +43,15 @@ See {ref}`listeners` for more details.
 
 ## Bugfixes in 2.3.2
 
--
+- Fixes [#449](https://github.com/fgmacedo/python-statemachine/issues/449): Regression that did not trigger events
+  in nested calls within an already running transition.
+
 
 ## Deprecation notes
 
-### Statemachine class
+### Statemachine class deprecations in 2.3.2
+
+Deprecations that will be removed on the next major release:
 
 - `StateMachine.add_observer` is deprecated in favor of `StateMachine.add_listener`.
+- `StateMachine.rtc` option is deprecated. We'll keep only the **run-to-completion** (RTC) model.

--- a/statemachine/event.py
+++ b/statemachine/event.py
@@ -15,15 +15,15 @@ class Event:
     def __repr__(self):
         return f"{type(self).__name__}({self.name!r})"
 
-    async def trigger(self, machine: "StateMachine", *args, **kwargs):
+    def trigger(self, machine: "StateMachine", *args, **kwargs):
         trigger_data = TriggerData(
             machine=machine,
             event=self.name,
             args=args,
             kwargs=kwargs,
         )
-
-        return await machine._process(trigger_data)
+        machine._put_nonblocking(trigger_data)
+        return machine._processing_loop()
 
 
 def trigger_event_factory(event_instance: Event):

--- a/statemachine/event_data.py
+++ b/statemachine/event_data.py
@@ -47,6 +47,7 @@ class EventData:
     """The destination :ref:`State` of the :ref:`transition`."""
 
     result: "Any | None" = None
+
     executed: bool = False
 
     def __post_init__(self):

--- a/tests/testcases/issue449.md
+++ b/tests/testcases/issue449.md
@@ -37,8 +37,6 @@ Exercise:
 
 
 ```py
->>> import pytest
->>> pytest.xfail("This test is a regression on 2.3.0+ due to asyncio support.")
 >>> example = ExampleStateMachine()
 Entering state initial. Event: __initial__
 


### PR DESCRIPTION
- chore: Processing block protected by a threading.Lock
- fix: Regression that did not trigger events in nested calls within an already running transition. Closes #449
