### PR TITLE
fix: Regression that broke sync callbacks interacting with Django ORM. Closes #446

### DIFF
--- a/docs/releases/2.3.2.md
+++ b/docs/releases/2.3.2.md
@@ -43,6 +43,9 @@ See {ref}`listeners` for more details.
 
 ## Bugfixes in 2.3.2
 
+- Fixes [#446](https://github.com/fgmacedo/python-statemachine/issues/446): Regression that broke sync callbacks
+  interacting with Django ORM due to the added async support and
+  [Django's async safety guards](https://docs.djangoproject.com/en/5.1/topics/async/#async-safety).
 - Fixes [#449](https://github.com/fgmacedo/python-statemachine/issues/449): Regression that did not trigger events
   in nested calls within an already running transition.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import sys
 from datetime import datetime
 from typing import List
+from unittest.mock import patch
 
 import pytest
 
@@ -197,3 +198,9 @@ def approval_machine(current_time):  # noqa: C901
             return self.model
 
     return ApprovalMachine
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _mock_sync_to_async():
+    with patch("statemachine.signature.sync_to_async", None):
+        yield

--- a/tests/django_project/core/settings.py
+++ b/tests/django_project/core/settings.py
@@ -18,7 +18,10 @@ INSTALLED_APPS = [
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": ":memory:",
+        "NAME": BASE_DIR / "db.sqlite3",
+        "TEST": {
+            "NAME": "testdb.sqlite3",
+        },
     }
 }
 


### PR DESCRIPTION
CLoses #446 .

I've added a `sync_to_async` wrap around sync callbacks if `asgiref` is available, as pointed out [in Django's async safety docs](https://docs.djangoproject.com/en/5.1/topics/async/#async-safety).