### PR TITLE
macedo/refac dispatcher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ convention = "google"
 
 [tool.coverage.run]
 branch = true
+dynamic_context = "test_function"
 relative_files = true
 data_file = ".coverage"
 source = ["statemachine"]
@@ -177,3 +178,4 @@ exclude_lines = [
 
 [tool.coverage.html]
 directory = "tmp/htmlcov"
+show_contexts = true

--- a/statemachine/dispatcher.py
+++ b/statemachine/dispatcher.py
@@ -63,17 +63,14 @@ class Listeners:
         allowed_references: SpecReference = SPECS_ALL,
     ):
         found_convention_specs = specs.conventional_specs & self.all_attrs
-        filtered_specs = [
-            spec
-            for spec in specs
-            if spec.reference in allowed_references
-            and (not spec.is_convention or spec.func in found_convention_specs)
-        ]
-        if not filtered_specs:
-            return
 
-        for spec in filtered_specs:
-            registry[spec.group.build_key(specs)]._add(spec, self)
+        for spec in specs:
+            if (spec.reference not in allowed_references) or (
+                spec.is_convention and spec.func not in found_convention_specs
+            ):
+                continue
+
+            registry.add(specs.grouper(spec.group).key, callbacks=spec.build(self))
 
     def search(self, spec: "CallbackSpec") -> Generator["Callable", None, None]:
         if spec.reference is SpecReference.NAME:

--- a/statemachine/dispatcher.py
+++ b/statemachine/dispatcher.py
@@ -5,7 +5,6 @@ from operator import attrgetter
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Set
@@ -26,23 +25,6 @@ if TYPE_CHECKING:
     from .callbacks import CallbackSpec
     from .callbacks import CallbackSpecList
     from .callbacks import CallbacksRegistry
-
-RegistryCallable = Callable[[str, "CallbackSpec", Callable[[], Callable]], None]
-
-
-class DictRegistry:
-    def __init__(self) -> None:
-        self._callbacks: Dict[str, Callable] = {}
-
-    def __call__(self, key: str, spec: "CallbackSpec", builder: Callable[[], Callable]) -> None:
-        if key not in self._callbacks:
-            callback = builder()
-            self._callbacks[key] = callback
-            callback.unique_key = key  # type: ignore[attr-defined]
-
-    @property
-    def callbacks(self) -> List[Callable]:
-        return list(self._callbacks.values())
 
 
 @dataclass
@@ -100,15 +82,15 @@ class Listeners:
                 continue
 
             executor = registry[specs.grouper(spec.group).key]
-            self.build(spec, registry=executor.add)
+            for key, builder in self.build(spec):
+                executor.add(key, spec, builder)
 
-    def _take_callback(
-        self, name: str, spec: "CallbackSpec", names_not_found_handler: Callable
-    ) -> Callable:
-        custom_registry = DictRegistry()
-
-        self.search_name(name, spec, custom_registry)
-        callbacks = custom_registry.callbacks
+    def _take_callback(self, name: str, names_not_found_handler: Callable) -> Callable:
+        callbacks: List[Callable] = []
+        for key, builder in self.search_name(name):
+            callback = builder()
+            callback.unique_key = key  # type: ignore[attr-defined]
+            callbacks.append(callback)
 
         if len(callbacks) == 0:
             names_not_found_handler(name)
@@ -118,7 +100,7 @@ class Listeners:
         else:
             return reduce(custom_and, callbacks)
 
-    def build(self, spec: "CallbackSpec", registry: RegistryCallable):
+    def build(self, spec: "CallbackSpec"):
         """
         Resolves the `spec` into callables in the `registry`.
 
@@ -127,14 +109,14 @@ class Listeners:
             registry (callable): A callable that will be used to store the resolved callables.
         """
         if not spec.may_contain_boolean_expression:
-            self.search(spec, registry=registry)
+            yield from self.search(spec)
             return
 
         # Resolves boolean expressions
 
         names_not_found: Set[str] = set()
         take_callback_partial = partial(
-            self._take_callback, spec=spec, names_not_found_handler=names_not_found.add
+            self._take_callback, names_not_found_handler=names_not_found.add
         )
 
         try:
@@ -147,19 +129,19 @@ class Listeners:
             spec.names_not_found = names_not_found
             return
 
-        registry(expression.unique_key, spec, lambda: expression)
+        yield expression.unique_key, lambda: expression
 
-    def search(self, spec: "CallbackSpec", registry: RegistryCallable):
+    def search(self, spec: "CallbackSpec"):
         if spec.reference is SpecReference.NAME:
-            self.search_name(spec.attr_name, spec, registry)
+            yield from self.search_name(spec.attr_name)
         elif spec.reference is SpecReference.CALLABLE:
-            self._search_callable(spec, registry)
+            yield from self._search_callable(spec)
         elif spec.reference is SpecReference.PROPERTY:
-            self._search_property(spec, registry)
+            yield from self._search_property(spec)
         else:  # never reached here from tests but put an exception for safety. pragma: no cover
             raise ValueError(f"Invalid reference {spec.reference}")
 
-    def _search_property(self, spec, registry: RegistryCallable):
+    def _search_property(self, spec):
         # if the attr is a property, we'll try to find the object that has the
         # property on the configs
         attr_name = spec.attr_name
@@ -168,28 +150,25 @@ class Listeners:
         for listener in self.items:
             func = getattr(type(listener.obj), attr_name, None)
             if func is not None and func is spec.func:
-                registry(
+                yield (
                     listener.build_key(attr_name),
-                    spec,
                     partial(attr_method, attr_name, listener.obj),
                 )
                 return
 
-    def _search_callable(self, spec, registry: RegistryCallable):
+    def _search_callable(self, spec):
         # if the attr is an unbounded method, we'll try to find the bounded method
         # on the self
         if not spec.is_bounded:
             for listener in self.items:
                 func = getattr(listener.obj, spec.attr_name, None)
                 if func is not None and func.__func__ is spec.func:
-                    registry(
-                        listener.build_key(spec.attr_name), spec, partial(callable_method, func)
-                    )
+                    yield listener.build_key(spec.attr_name), partial(callable_method, func)
                     return
 
-        registry(f"{spec.attr_name}@None", spec, partial(callable_method, spec.func))
+        yield f"{spec.attr_name}@None", partial(callable_method, spec.func)
 
-    def search_name(self, name, spec, registry: RegistryCallable):
+    def search_name(self, name):
         for listener in self.items:
             if name not in listener.all_attrs:
                 continue
@@ -197,14 +176,14 @@ class Listeners:
             key = listener.build_key(name)
             func = getattr(listener.obj, name)
             if not callable(func):
-                registry(key, spec, partial(attr_method, name, listener.obj))
+                yield key, partial(attr_method, name, listener.obj)
                 continue
 
             if isinstance(func, Event):
-                registry(key, spec, partial(event_method, func))
+                yield key, partial(event_method, func)
                 continue
 
-            registry(key, spec, partial(callable_method, func))
+            yield key, partial(callable_method, func)
 
 
 def callable_method(a_callable) -> Callable:

--- a/statemachine/dispatcher.py
+++ b/statemachine/dispatcher.py
@@ -120,11 +120,11 @@ class Listeners:
 
     def build(self, spec: "CallbackSpec", registry: RegistryCallable):
         """
-        Resolves the `func` into a usable callable.
+        Resolves the `spec` into callables in the `registry`.
 
         Args:
-            resolver (callable): A method responsible to build and return a valid callable that
-                can receive arbitrary parameters like `*args, **kwargs`.
+            spec (CallbackSpec): A spec to be resolved.
+            registry (callable): A callable that will be used to store the resolved callables.
         """
         if not spec.may_contain_boolean_expression:
             self.search(spec, registry=registry)

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -1,7 +1,6 @@
 import warnings
 from collections import deque
 from copy import deepcopy
-from functools import partial
 from inspect import isawaitable
 from threading import Lock
 from typing import TYPE_CHECKING
@@ -181,13 +180,13 @@ class StateMachine(metaclass=StateMachineMetaclass):
                 setattr(target, event, trigger)
 
     def _add_listener(self, listeners: "Listeners", allowed_references: SpecReference = SPECS_ALL):
-        register = partial(
-            listeners.resolve,
-            registry=self._callbacks_registry,
-            allowed_references=allowed_references,
-        )
+        registry = self._callbacks_registry
         for visited in iterate_states_and_transitions(self.states):
-            register(visited._specs)
+            listeners.resolve(
+                visited._specs,
+                registry=registry,
+                allowed_references=allowed_references,
+            )
 
         return self
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -5,7 +5,6 @@ import pytest
 from statemachine import State
 from statemachine import StateMachine
 from statemachine.callbacks import CallbackGroup
-from statemachine.callbacks import CallbacksExecutor
 from statemachine.callbacks import CallbackSpec
 from statemachine.callbacks import CallbackSpecList
 from statemachine.callbacks import CallbacksRegistry
@@ -38,25 +37,6 @@ def ObjectWithCallbacks():
 
 
 class TestCallbacksMachinery:
-    def test_can_add_callback(self):
-        meta_list = CallbackSpecList()
-        executor = CallbacksExecutor()
-
-        func = mock.Mock()
-
-        class MyObject:
-            def do_something(self, *args, **kwargs):
-                return func(*args, **kwargs)
-
-        obj = MyObject()
-
-        meta_list.add(obj.do_something, group=CallbackGroup.ON)
-        executor.add(meta_list, resolver_factory_from_objects(obj))
-
-        executor.call(1, 2, 3, a="x", b="y")
-
-        func.assert_called_once_with(1, 2, 3, a="x", b="y")
-
     def test_callback_meta_is_hashable(self):
         wrapper = CallbackSpec("something", group=CallbackGroup.ON)
         set().add(wrapper)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -2,13 +2,17 @@ import pytest
 
 from statemachine.callbacks import CallbackGroup
 from statemachine.callbacks import CallbackSpec
-from statemachine.dispatcher import DictRegistry
 from statemachine.dispatcher import Listener
 from statemachine.dispatcher import Listeners
 from statemachine.dispatcher import resolver_factory_from_objects
 from statemachine.exceptions import InvalidDefinition
 from statemachine.state import State
 from statemachine.statemachine import StateMachine
+
+
+def _take_first_callable(iterable):
+    _key, builder = next(iterable)
+    return builder()
 
 
 class Person:
@@ -52,23 +56,22 @@ class TestEnsureCallable:
     def test_return_same_object_if_already_a_callable(self):
         model = Person("Frodo", "Bolseiro")
         expected = model.get_full_name
-        registry = DictRegistry()
-        resolver_factory_from_objects([]).search(
-            CallbackSpec(model.get_full_name, group=CallbackGroup.ON), registry=registry
+        actual = _take_first_callable(
+            resolver_factory_from_objects([]).search(
+                CallbackSpec(model.get_full_name, group=CallbackGroup.ON)
+            )
         )
-        actual = registry.callbacks[0]
         assert actual.__name__ == expected.__name__
         assert actual.__doc__ == expected.__doc__
 
     def test_retrieve_a_method_from_its_name(self, args, kwargs):
         model = Person("Frodo", "Bolseiro")
         expected = model.get_full_name
-        registry = DictRegistry()
-        Listeners.from_listeners([Listener.from_obj(model)]).search(
-            CallbackSpec("get_full_name", group=CallbackGroup.ON),
-            registry=registry,
+        method = _take_first_callable(
+            Listeners.from_listeners([Listener.from_obj(model)]).search(
+                CallbackSpec("get_full_name", group=CallbackGroup.ON),
+            )
         )
-        method = registry.callbacks[0]
 
         assert method.__name__ == expected.__name__
         assert method.__doc__ == expected.__doc__
@@ -76,25 +79,23 @@ class TestEnsureCallable:
 
     def test_retrieve_a_callable_from_a_property_name(self, args, kwargs):
         model = Person("Frodo", "Bolseiro")
-        registry = DictRegistry()
 
-        Listeners.from_listeners([Listener.from_obj(model)]).search(
-            CallbackSpec("first_name", group=CallbackGroup.ON),
-            registry=registry,
+        method = _take_first_callable(
+            Listeners.from_listeners([Listener.from_obj(model)]).search(
+                CallbackSpec("first_name", group=CallbackGroup.ON),
+            )
         )
-        method = registry.callbacks[0]
 
         assert method(*args, **kwargs) == "Frodo"
 
     def test_retrieve_callable_from_a_property_name_that_should_keep_reference(self, args, kwargs):
         model = Person("Frodo", "Bolseiro")
-        registry = DictRegistry()
 
-        Listeners.from_listeners([Listener.from_obj(model)]).search(
-            CallbackSpec("first_name", group=CallbackGroup.ON),
-            registry=registry,
+        method = _take_first_callable(
+            Listeners.from_listeners([Listener.from_obj(model)]).search(
+                CallbackSpec("first_name", group=CallbackGroup.ON),
+            )
         )
-        method = registry.callbacks[0]
 
         model.first_name = "Bilbo"
 
@@ -116,9 +117,9 @@ class TestResolverFactory:
         org = Organization("The Lord fo the Rings", "cnpj")
 
         resolver = resolver_factory_from_objects(org, person)
-        registry = DictRegistry()
-        resolver.search(CallbackSpec(attr, group=CallbackGroup.ON), registry=registry)
-        resolved_method = registry.callbacks[0]
+        resolved_method = _take_first_callable(
+            resolver.search(CallbackSpec(attr, group=CallbackGroup.ON))
+        )
         assert resolved_method() == expected_value
 
     @pytest.mark.parametrize(
@@ -137,9 +138,9 @@ class TestResolverFactory:
         org_config = Listener.from_obj(org, {"get_full_name"})
 
         resolver = resolver_factory_from_objects(org_config, person)
-        registry = DictRegistry()
-        resolver.search(CallbackSpec(attr, group=CallbackGroup.ON), registry=registry)
-        resolved_method = registry.callbacks[0]
+        resolved_method = _take_first_callable(
+            resolver.search(CallbackSpec(attr, group=CallbackGroup.ON))
+        )
         assert resolved_method() == expected_value
 
 


### PR DESCRIPTION
- refac: Removing registry's dependency of Listeners
- refac: Move all callback search to the dispatcher module
