### PR TITLE
feat: Allow using event as decorator to register callbacks

### DIFF
--- a/statemachine/engines/base.py
+++ b/statemachine/engines/base.py
@@ -3,8 +3,7 @@ from threading import Lock
 from typing import TYPE_CHECKING
 from weakref import proxy
 
-from statemachine.event import BoundEvent
-
+from ..event import BoundEvent
 from ..event_data import TriggerData
 from ..state import State
 from ..transition import Transition

--- a/statemachine/event.py
+++ b/statemachine/event.py
@@ -3,10 +3,9 @@ from typing import TYPE_CHECKING
 from typing import List
 from uuid import uuid4
 
-from statemachine.exceptions import InvalidDefinition
-
 from .callbacks import CallbackGroup
 from .event_data import TriggerData
+from .exceptions import InvalidDefinition
 from .i18n import _
 from .transition_mixin import AddCallbacksMixin
 from .utils import run_async_from_sync

--- a/statemachine/events.py
+++ b/statemachine/events.py
@@ -1,5 +1,4 @@
-from statemachine.event import Event
-
+from .event import Event
 from .utils import ensure_iterable
 
 

--- a/statemachine/transition_list.py
+++ b/statemachine/transition_list.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING
-from typing import Callable
 from typing import Iterable
 from typing import List
 
 from .callbacks import CallbackGroup
 from .transition import Transition
+from .transition_mixin import AddCallbacksMixin
 from .utils import ensure_iterable
 
 if TYPE_CHECKING:
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from .state import State
 
 
-class TransitionList:
+class TransitionList(AddCallbacksMixin):
     """A list-like container of :ref:`transitions` with callback functions."""
 
     def __init__(self, transitions: "Iterable[Transition] | None" = None):
@@ -96,80 +96,6 @@ class TransitionList:
                 **kwargs,
             )
         return callback
-
-    def __call__(self, f):
-        return self._add_callback(f, CallbackGroup.ON, is_event=True)
-
-    def before(self, f: Callable):
-        """Adds a ``before`` :ref:`transition actions` callback to every :ref:`transition` in the
-        :ref:`TransitionList` instance.
-
-        Args:
-            f: The ``before`` :ref:`transition actions` callback function to be added.
-
-        Returns:
-            The `f` callable.
-        """
-        return self._add_callback(f, CallbackGroup.BEFORE)
-
-    def after(self, f: Callable):
-        """Adds a ``after`` :ref:`transition actions` callback to every :ref:`transition` in the
-        :ref:`TransitionList` instance.
-
-        Args:
-            f: The ``after`` :ref:`transition actions` callback function to be added.
-
-        Returns:
-            The `f` callable.
-        """
-        return self._add_callback(f, CallbackGroup.AFTER)
-
-    def on(self, f: Callable):
-        """Adds a ``on`` :ref:`transition actions` callback to every :ref:`transition` in the
-        :ref:`TransitionList` instance.
-
-        Args:
-            f: The ``on`` :ref:`transition actions` callback function to be added.
-
-        Returns:
-            The `f` callable.
-        """
-        return self._add_callback(f, CallbackGroup.ON)
-
-    def cond(self, f: Callable):
-        """Adds a ``cond`` :ref:`guards` callback to every :ref:`transition` in the
-        :ref:`TransitionList` instance.
-
-        Args:
-            f: The ``cond`` :ref:`guards` callback function to be added.
-
-        Returns:
-            The `f` callable.
-        """
-        return self._add_callback(f, CallbackGroup.COND, expected_value=True)
-
-    def unless(self, f: Callable):
-        """Adds a ``unless`` :ref:`guards` callback with expected value ``False`` to every
-        :ref:`transition` in the :ref:`TransitionList` instance.
-
-        Args:
-            f: The ``unless`` :ref:`guards` callback function to be added.
-
-        Returns:
-            The `f` callable.
-        """
-        return self._add_callback(f, CallbackGroup.COND, expected_value=False)
-
-    def validators(self, f: Callable):
-        """Adds a :ref:`validators` callback to the :ref:`TransitionList` instance.
-
-        Args:
-            f: The ``validators`` callback function to be added.
-        Returns:
-            The callback function.
-
-        """
-        return self._add_callback(f, CallbackGroup.VALIDATOR)
 
     def add_event(self, event: str):
         """

--- a/statemachine/transition_mixin.py
+++ b/statemachine/transition_mixin.py
@@ -1,0 +1,82 @@
+from typing import Callable
+
+from .callbacks import CallbackGroup
+
+
+class AddCallbacksMixin:
+    def _add_callback(self, callback, grouper: CallbackGroup, is_event=False, **kwargs):
+        raise NotImplementedError
+
+    def __call__(self, f):
+        return self._add_callback(f, CallbackGroup.ON, is_event=True)
+
+    def before(self, f: Callable):
+        """Adds a ``before`` :ref:`transition actions` callback to every :ref:`transition` in the
+        :ref:`TransitionList` instance.
+
+        Args:
+            f: The ``before`` :ref:`transition actions` callback function to be added.
+
+        Returns:
+            The `f` callable.
+        """
+        return self._add_callback(f, CallbackGroup.BEFORE)
+
+    def after(self, f: Callable):
+        """Adds a ``after`` :ref:`transition actions` callback to every :ref:`transition` in the
+        :ref:`TransitionList` instance.
+
+        Args:
+            f: The ``after`` :ref:`transition actions` callback function to be added.
+
+        Returns:
+            The `f` callable.
+        """
+        return self._add_callback(f, CallbackGroup.AFTER)
+
+    def on(self, f: Callable):
+        """Adds a ``on`` :ref:`transition actions` callback to every :ref:`transition` in the
+        :ref:`TransitionList` instance.
+
+        Args:
+            f: The ``on`` :ref:`transition actions` callback function to be added.
+
+        Returns:
+            The `f` callable.
+        """
+        return self._add_callback(f, CallbackGroup.ON)
+
+    def cond(self, f: Callable):
+        """Adds a ``cond`` :ref:`guards` callback to every :ref:`transition` in the
+        :ref:`TransitionList` instance.
+
+        Args:
+            f: The ``cond`` :ref:`guards` callback function to be added.
+
+        Returns:
+            The `f` callable.
+        """
+        return self._add_callback(f, CallbackGroup.COND, expected_value=True)
+
+    def unless(self, f: Callable):
+        """Adds a ``unless`` :ref:`guards` callback with expected value ``False`` to every
+        :ref:`transition` in the :ref:`TransitionList` instance.
+
+        Args:
+            f: The ``unless`` :ref:`guards` callback function to be added.
+
+        Returns:
+            The `f` callable.
+        """
+        return self._add_callback(f, CallbackGroup.COND, expected_value=False)
+
+    def validators(self, f: Callable):
+        """Adds a :ref:`validators` callback to the :ref:`TransitionList` instance.
+
+        Args:
+            f: The ``validators`` callback function to be added.
+        Returns:
+            The callback function.
+
+        """
+        return self._add_callback(f, CallbackGroup.VALIDATOR)


### PR DESCRIPTION
Allows using the same constructs on `Event` as in the `TransitionList` for registering callbacks using the decorator syntax.

Relates to #503 as a desired addition.