### PR TITLE
tests: Ignore tests that requires dot if the executable is not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ You can now create an instance:
 This state machine can be represented graphically as follows:
 
 ```py
+>>> # This example will only run on automated tests if dot is present
+>>> getfixture("requires_dot_installed")
 >>> img_path = "docs/images/readme_trafficlightmachine.png"
 >>> sm._graph().write_png(img_path)
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import shutil
 import sys
 
 import pytest
@@ -31,3 +32,14 @@ def pytest_ignore_collect(collection_path, path, config):
 
     if "django_project" in str(path):
         return True
+
+
+@pytest.fixture(scope="session")
+def has_dot_installed():
+    return bool(shutil.which("dot"))
+
+
+@pytest.fixture()
+def requires_dot_installed(request, has_dot_installed):
+    if not has_dot_installed:
+        pytest.skip(f"Test {request.node.nodeid} requires 'dot' that is not installed.")

--- a/docs/diagram.md
+++ b/docs/diagram.md
@@ -74,6 +74,8 @@ If you find the resolution of the image lacking, you can
 The current {ref}`state` is also highlighted:
 
 ``` py
+>>> # This example will only run on automated tests if dot is present
+>>> getfixture("requires_dot_installed")
 
 >>> from statemachine.contrib.diagram import DotGraphMachine
 

--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -131,6 +131,9 @@ Example:
 Usage:
 
 ```py
+>>> # This example will only run on automated tests if dot is present
+>>> getfixture("requires_dot_installed")
+
 >>> sm = TestStateMachine()
 
 >>> sm._graph().write_png("docs/images/test_state_machine_internal.png")

--- a/tests/test_contrib_diagram.py
+++ b/tests/test_contrib_diagram.py
@@ -7,6 +7,8 @@ from statemachine.contrib.diagram import DotGraphMachine
 from statemachine.contrib.diagram import main
 from statemachine.contrib.diagram import quickchart_write_svg
 
+pytestmark = pytest.mark.usefixtures("requires_dot_installed")
+
 
 @pytest.fixture(
     params=[


### PR DESCRIPTION
Using a new notebook, noted that the first run of the tests failed because the graphviz was missing. 

Turned these tests optional and skipped if the dot executable is not present.