### PR TITLE
Docs: Fix root project contributing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ https://python-statemachine.readthedocs.io.
 - If you found this project helpful, please consider giving it a star on GitHub.
 
 - **Contribute code**: If you would like to contribute code, please submit a pull
-request. For more information on how to contribute, please see our [contributing.md](contributing.md) file.
+request. For more information on how to contribute, please see our [contributing.md](docs/contributing.md) file.
 
 - **Report bugs**: If you find any bugs, please report them by opening an issue
   on our GitHub issue tracker.

--- a/contributing.md
+++ b/contributing.md
@@ -1,1 +1,1 @@
-Please see [docs/contributing.md](docs/contributing).
+Please see [docs/contributing.md](docs/contributing.md).


### PR DESCRIPTION
`/contributing.md` redirected users to `/docs/contributing.md` but the link was broken (missing file extension).

`/README.md` pointed users to `/contributing.md` so this has been updated to the new location `/docs/contributing.md` to eliminate an additional step