### PR TITLE
Fix domain model bool check

### DIFF
--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -75,7 +75,7 @@ class StateMachine(metaclass=StateMachineMetaclass):
         allow_event_without_transition: bool = False,
         listeners: "List[object] | None" = None,
     ):
-        self.model = model if model else Model()
+        self.model = model if model is not None else Model()
         self.state_field = state_field
         self.start_value = start_value
         self.allow_event_without_transition = allow_event_without_transition

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -488,3 +488,18 @@ class TestWarnings:
                 start = started.to(producing)
                 close = started.to(closed)
                 add_job = producing.to.itself(internal=True)
+
+
+def test_model_with_custom_bool_is_not_replaced(campaign_machine):
+    class FalseyModel(MyModel):
+        def __bool__(self):
+            return False
+
+    model = FalseyModel()
+    machine = campaign_machine(model)
+
+    assert machine.model is model
+    assert model.state == "draft"
+
+    machine.produce()
+    assert model.state == "producing"


### PR DESCRIPTION
## Summary
- ensure state machine keeps a provided model even if it's falsy
- test `__bool__` domain model

## Testing
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859bdb3d6d8832f917afa1e3e99b283