### PR TITLE
fix: Add return type annotations for async-compatible methods

### DIFF
--- a/statemachine/event.py
+++ b/statemachine/event.py
@@ -1,5 +1,6 @@
 from inspect import isawaitable
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import List
 from uuid import uuid4
 
@@ -108,7 +109,7 @@ class Event(AddCallbacksMixin, str):
             return self
         return BoundEvent(id=self.id, name=self.name, _sm=instance)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs) -> Any:
         """Send this event to the current state machine.
 
         Triggering an event on a state machine means invoking or sending a signal, initiating the

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -102,13 +102,13 @@ class StateMachine(metaclass=StateMachineMetaclass):
 
         return SyncEngine(self, rtc=rtc)
 
-    def activate_initial_state(self):
+    def activate_initial_state(self) -> Any:
         result = self._engine.activate_initial_state()
         if not isawaitable(result):
             return result
         return run_async_from_sync(result)
 
-    def _processing_loop(self):
+    def _processing_loop(self) -> Any:
         return self._engine.processing_loop()
 
     def __init_subclass__(cls, strict_states: bool = False):
@@ -298,7 +298,7 @@ class StateMachine(metaclass=StateMachineMetaclass):
         """Put the trigger on the queue without blocking the caller."""
         self._engine.put(trigger_data)
 
-    def send(self, event: str, *args, **kwargs):
+    def send(self, event: str, *args, **kwargs) -> Any:
         """Send an :ref:`Event` to the state machine.
 
         .. seealso::

--- a/statemachine/utils.py
+++ b/statemachine/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import threading
+from typing import Any
 
 _cached_loop = threading.local()
 """Loop that will be used when the SM is running in a synchronous context. One loop per thread."""
@@ -25,7 +26,7 @@ def ensure_iterable(obj):
         return [obj]
 
 
-def run_async_from_sync(coroutine):
+def run_async_from_sync(coroutine: Any) -> Any:
     """
     Compatibility layer to run an async coroutine from a synchronous context.
     """


### PR DESCRIPTION
Methods `activate_initial_state()`, `send()`, `_processing_loop()`, and `Event.__call__()` can return a coroutine when `AsyncEngine` is active, but their type signatures did not reflect this, causing type checkers to report `Type 'bool' is not awaitable` errors.

### What changed

Added `-> Any` return type annotation to:
- `run_async_from_sync()` in `utils.py`  
- `activate_initial_state()` in `statemachine.py`
- `_processing_loop()` in `statemachine.py`
- `send()` in `statemachine.py`
- `Event.__call__()` in `event.py`

### Minimal reproduction

```python
class MyMachine(StateMachine):
    initial = State(initial=True)
    final = State(final=True)
    go = initial.to(final)

    # This single async callback forces AsyncEngine
    async def on_enter_final(self) -> None:
        pass
```

```python
async def main() -> None:
    sm = MyMachine()
    await sm.activate_initial_state()  # ← type error before fix
    await sm.send("go")               # ← type error before fix
```