### PR TITLE
fix: handle VAR_POSITIONAL and kwargs precedence in _fast_bind cache

### DIFF
--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -2,6 +2,7 @@ import inspect
 from functools import partial
 
 import pytest
+
 from statemachine.dispatcher import callable_method
 from statemachine.signature import SignatureAdapter
 
@@ -196,3 +197,97 @@ class TestCachedBindExpected:
 
         result2 = wrapped("X", target="Y")
         assert result2 == ("X", {"target": "Y"})
+
+    def test_var_positional_collected_as_tuple(self):
+        """VAR_POSITIONAL (*args) must be collected into a tuple on cache hit."""
+
+        def fn(*args, **kwargs):
+            return args, kwargs
+
+        wrapped = callable_method(fn)
+
+        result1 = wrapped(1, 2, 3, key="val")
+        assert result1 == ((1, 2, 3), {"key": "val"})
+
+        result2 = wrapped(4, 5, key="other")
+        assert result2 == ((4, 5), {"key": "other"})
+
+    def test_keyword_only_after_var_positional(self):
+        """KEYWORD_ONLY params after *args must be extracted from kwargs on cache hit."""
+
+        def fn(*args, event, **kwargs):
+            return args, event, kwargs
+
+        wrapped = callable_method(fn)
+
+        result1 = wrapped(100, event="ev1", source="s0")
+        assert result1 == ((100,), "ev1", {"source": "s0"})
+
+        result2 = wrapped(200, event="ev2", source="s1")
+        assert result2 == ((200,), "ev2", {"source": "s1"})
+
+    def test_positional_or_keyword_prefers_kwargs_over_positional(self):
+        """When a POSITIONAL_OR_KEYWORD param is in both args and kwargs, kwargs wins."""
+
+        def fn(event, source, target):
+            return event, source, target
+
+        wrapped = callable_method(fn)
+
+        # 1st call: positional arg provided but 'event' also in kwargs -> kwargs wins
+        result1 = wrapped("discarded_content", event="ev1", source="s0", target="t0")
+        assert result1 == ("ev1", "s0", "t0")
+
+        # 2nd call: cache hit, same behavior expected
+        result2 = wrapped("other_content", event="ev2", source="s1", target="t1")
+        assert result2 == ("ev2", "s1", "t1")
+
+    def test_empty_var_positional(self):
+        """Empty *args is handled correctly on cache hit."""
+
+        def fn(*args, **kwargs):
+            return args, kwargs
+
+        wrapped = callable_method(fn)
+
+        # 1st call with args
+        result1 = wrapped(1, key="val")
+        assert result1 == ((1,), {"key": "val"})
+
+        # 2nd call: only kwargs, no positional args — different cache key (len=0)
+        result2 = wrapped(key="val2")
+        assert result2 == ((), {"key": "val2"})
+
+        # 3rd call: hits cache for len=0
+        result3 = wrapped(key="val3")
+        assert result3 == ((), {"key": "val3"})
+
+    def test_named_params_before_var_positional(self):
+        """Named params before *args are filled correctly on cache hit."""
+
+        def fn(a, b, *args, **kwargs):
+            return a, b, args, kwargs
+
+        wrapped = callable_method(fn)
+
+        result1 = wrapped(1, 2, 3, 4, key="val")
+        assert result1 == (1, 2, (3, 4), {"key": "val"})
+
+        result2 = wrapped(10, 20, 30, key="val2")
+        assert result2 == (10, 20, (30,), {"key": "val2"})
+
+    def test_kwargs_wins_with_var_positional_present(self):
+        """POSITIONAL_OR_KEYWORD before *args prefers kwargs when name matches."""
+
+        def fn(event, *args, **kwargs):
+            return event, args, kwargs
+
+        wrapped = callable_method(fn)
+
+        # 1st call: 'event' in both positional and kwargs — kwargs wins
+        result1 = wrapped("discarded", "extra", event="ev1", key="a")
+        assert result1 == ("ev1", ("extra",), {"key": "a"})
+
+        # 2nd call: cache hit, same behavior
+        result2 = wrapped("other", "more", event="ev2", key="b")
+        assert result2 == ("ev2", ("more",), {"key": "b"})


### PR DESCRIPTION
## Summary

Fixes three bugs in the `_fast_bind` cached path introduced by #550:

- **VAR_POSITIONAL (`*args`)**: Was stored as raw `args[i]` instead of `args[i:]` tuple, causing `TypeError: 'int' object is not iterable` in `BoundArguments.args`
- **KEYWORD_ONLY after `*args`**: Params after `*args` (e.g., `def fn(*args, event, **kwargs)`) were skipped entirely — the loop broke at VAR_POSITIONAL without processing remaining keyword-only params
- **POSITIONAL_OR_KEYWORD kwargs precedence**: When a param name appears in both positional args and kwargs, `_full_bind` prefers kwargs, but `_fast_bind` always used the positional arg

These bugs only manifest when the `_bind_cache` (on a shared `SignatureAdapter` instance) is populated by one call shape and reused by another — e.g., across SCXML test cases that share callbacks via `signature_cache`.

## Test plan

- [x] Added `test_var_positional_collected_as_tuple` — verifies `*args` collected as tuple on cache hit
- [x] Added `test_keyword_only_after_var_positional` — verifies KEYWORD_ONLY params after `*args` work
- [x] Added `test_positional_or_keyword_prefers_kwargs_over_positional` — verifies kwargs precedence
- [x] Added `test_empty_var_positional` — verifies empty `*args` edge case
- [x] Added `test_named_params_before_var_positional` — verifies named params before `*args`
- [x] Added `test_kwargs_wins_with_var_positional_present` — verifies kwargs precedence with `*args`
- [x] Full test suite passes (357 passed, 9 xfailed)

Fixes SCXML W3C test failures (test179, test527, test529, test562, test578) on the `macedo/scxml` branch CI.