### PR TITLE
feat: add enabled_events() method (#520)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         exclude: docs/auto_examples
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   # Ruff version.
-  rev: v0.8.1
+  rev: v0.15.0
   hooks:
     # Run the linter.
     - id: ruff

--- a/statemachine/engines/async_.py
+++ b/statemachine/engines/async_.py
@@ -97,6 +97,34 @@ class AsyncEngine(BaseEngine):
 
         return result if executed else None
 
+    async def enabled_events(self, *args, **kwargs):
+        sm = self.sm
+        enabled = {}
+        for transition in sm.current_state.transitions:
+            for event in transition.events:
+                if event in enabled:
+                    continue
+                extended_kwargs = kwargs.copy()
+                extended_kwargs.update(
+                    {
+                        "machine": sm,
+                        "model": sm.model,
+                        "event": getattr(sm, event),
+                        "source": transition.source,
+                        "target": transition.target,
+                        "state": sm.current_state,
+                        "transition": transition,
+                    }
+                )
+                try:
+                    if await sm._callbacks.async_all(
+                        transition.cond.key, *args, **extended_kwargs
+                    ):
+                        enabled[event] = getattr(sm, event)
+                except Exception:
+                    enabled[event] = getattr(sm, event)
+        return list(enabled.values())
+
     async def _activate(self, trigger_data: TriggerData, transition: "Transition"):
         event_data = EventData(trigger_data=trigger_data, transition=transition)
         args, kwargs = event_data.args, event_data.extended_kwargs

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -147,6 +147,7 @@ class StateMachine(metaclass=StateMachineMetaclass):
         self._register_callbacks([])
         self.add_listener(*listeners.keys())
         self._engine = self._get_engine(rtc)
+        self._engine.start()
 
     def _get_initial_state(self):
         initial_state_value = self.start_value if self.start_value else self.initial_state.value

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -295,6 +295,24 @@ class StateMachine(metaclass=StateMachineMetaclass):
         """List of the current allowed events."""
         return [getattr(self, event) for event in self.current_state.transitions.unique_events]
 
+    def enabled_events(self, *args, **kwargs):
+        """List of the current enabled events, considering guard conditions.
+
+        An event is **enabled** if at least one of its transitions from the current
+        state has all ``cond``/``unless`` guards satisfied.
+
+        Args:
+            *args: Positional arguments forwarded to condition callbacks.
+            **kwargs: Keyword arguments forwarded to condition callbacks.
+
+        Returns:
+            A list of enabled :ref:`Event` instances.
+        """
+        result = self._engine.enabled_events(*args, **kwargs)
+        if not isawaitable(result):
+            return result
+        return run_async_from_sync(result)
+
     def _put_nonblocking(self, trigger_data: TriggerData):
         """Put the trigger on the queue without blocking the caller."""
         self._engine.put(trigger_data)

--- a/tests/examples/user_machine.py
+++ b/tests/examples/user_machine.py
@@ -14,9 +14,10 @@ And that logic can be reused with listeners.
 from dataclasses import dataclass
 from enum import Enum
 
+from statemachine.states import States
+
 from statemachine import State
 from statemachine import StateMachine
-from statemachine.states import States
 
 
 class UserStatus(str, Enum):

--- a/tests/examples/user_machine.py
+++ b/tests/examples/user_machine.py
@@ -14,10 +14,9 @@ And that logic can be reused with listeners.
 from dataclasses import dataclass
 from enum import Enum
 
-from statemachine.states import States
-
 from statemachine import State
 from statemachine import StateMachine
+from statemachine.states import States
 
 
 class UserStatus(str, Enum):
@@ -88,7 +87,7 @@ class UserStatusMachine(StateMachine):
     def on_signup(self, token: str):
         if token == "":
             raise ValueError("Token is required")
-        self.model.verified = True
+        self.model.verified = True  # type: ignore[union-attr]
 
 
 class UserExperienceMachine(StateMachine):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -116,7 +116,7 @@ class AsyncConditionExpressionMachine(StateMachine):
         return False
 
     async def on_enter_state(self, target):
-        pass
+        """Async callback to ensure the SM uses AsyncEngine."""
 
 
 async def test_async_condition_not(recwarn):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,10 +1,10 @@
 import re
 
 import pytest
-from statemachine.exceptions import InvalidStateValue
 
 from statemachine import State
 from statemachine import StateMachine
+from statemachine.exceptions import InvalidStateValue
 
 
 @pytest.fixture()
@@ -94,6 +94,86 @@ def test_async_state_from_sync_context(async_order_control_machine):
     assert sm.order_total == 10
     assert sm.payments == [4, 6]
     assert sm.completed.is_active
+
+
+class AsyncConditionExpressionMachine(StateMachine):
+    """Regression test for issue #535: async conditions in boolean expressions."""
+
+    s1 = State(initial=True)
+
+    go_not = s1.to.itself(cond="not cond_false")
+    go_and = s1.to.itself(cond="cond_true and cond_true")
+    go_or_false_first = s1.to.itself(cond="cond_false or cond_true")
+    go_or_true_first = s1.to.itself(cond="cond_true or cond_false")
+    go_blocked = s1.to.itself(cond="not cond_true")
+    go_and_blocked = s1.to.itself(cond="cond_true and cond_false")
+    go_or_both_false = s1.to.itself(cond="cond_false or cond_false")
+
+    async def cond_true(self):
+        return True
+
+    async def cond_false(self):
+        return False
+
+    async def on_enter_state(self, target):
+        pass
+
+
+async def test_async_condition_not(recwarn):
+    """Issue #535: 'not cond_false' should allow the transition."""
+    sm = AsyncConditionExpressionMachine()
+    await sm.activate_initial_state()
+    await sm.go_not()
+    assert sm.s1.is_active
+    assert not any("coroutine" in str(w.message) for w in recwarn.list)
+
+
+async def test_async_condition_not_blocked():
+    """Issue #535: 'not cond_true' should block the transition."""
+    sm = AsyncConditionExpressionMachine()
+    await sm.activate_initial_state()
+    with pytest.raises(sm.TransitionNotAllowed):
+        await sm.go_blocked()
+
+
+async def test_async_condition_and():
+    """Issue #535: 'cond_true and cond_true' should allow the transition."""
+    sm = AsyncConditionExpressionMachine()
+    await sm.activate_initial_state()
+    await sm.go_and()
+    assert sm.s1.is_active
+
+
+async def test_async_condition_and_blocked():
+    """Issue #535: 'cond_true and cond_false' should block the transition."""
+    sm = AsyncConditionExpressionMachine()
+    await sm.activate_initial_state()
+    with pytest.raises(sm.TransitionNotAllowed):
+        await sm.go_and_blocked()
+
+
+async def test_async_condition_or_false_first():
+    """Issue #535: 'cond_false or cond_true' should allow the transition."""
+    sm = AsyncConditionExpressionMachine()
+    await sm.activate_initial_state()
+    await sm.go_or_false_first()
+    assert sm.s1.is_active
+
+
+async def test_async_condition_or_true_first():
+    """'cond_true or cond_false' should allow the transition."""
+    sm = AsyncConditionExpressionMachine()
+    await sm.activate_initial_state()
+    await sm.go_or_true_first()
+    assert sm.s1.is_active
+
+
+async def test_async_condition_or_both_false():
+    """'cond_false or cond_false' should block the transition."""
+    sm = AsyncConditionExpressionMachine()
+    await sm.activate_initial_state()
+    with pytest.raises(sm.TransitionNotAllowed):
+        await sm.go_or_both_false()
 
 
 async def test_async_state_should_be_initialized(async_order_control_machine):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,10 +1,10 @@
 import re
 
 import pytest
+from statemachine.exceptions import InvalidStateValue
 
 from statemachine import State
 from statemachine import StateMachine
-from statemachine.exceptions import InvalidStateValue
 
 
 @pytest.fixture()

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -6,11 +6,11 @@ from enum import Enum
 from enum import auto
 
 import pytest
+from statemachine.exceptions import TransitionNotAllowed
+from statemachine.states import States
 
 from statemachine import State
 from statemachine import StateMachine
-from statemachine.exceptions import TransitionNotAllowed
-from statemachine.states import States
 
 logger = logging.getLogger(__name__)
 DEBUG = logging.DEBUG

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -192,7 +192,7 @@ class AsyncTrafficLightMachine(StateMachine):
     cycle = green.to(yellow) | yellow.to(red) | red.to(green)
 
     async def on_enter_state(self, target):
-        pass
+        """Async callback to ensure the SM uses AsyncEngine."""
 
 
 def test_copy_async_statemachine_before_activation(copy_method):

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -2,7 +2,6 @@ import inspect
 from functools import partial
 
 import pytest
-
 from statemachine.dispatcher import callable_method
 from statemachine.signature import SignatureAdapter
 

--- a/tests/test_spec_parser.py
+++ b/tests/test_spec_parser.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 
 import pytest
-
 from statemachine.spec_parser import operator_mapping
 from statemachine.spec_parser import parse_boolean_expr
 

--- a/tests/test_spec_parser.py
+++ b/tests/test_spec_parser.py
@@ -257,8 +257,11 @@ def async_variable_hook(var_name):
         "val_20": 20,
     }
 
+    value = values.get(var_name, False)
+
     async def decorated(*args, **kwargs):
-        return values.get(var_name, False)
+        await asyncio.sleep(0)
+        return value
 
     decorated.__name__ = var_name
     return decorated
@@ -301,9 +304,11 @@ def mixed_variable_hook(var_name):
     async_values = {"async_true": True, "async_false": False, "async_20": 20}
 
     if var_name in async_values:
+        value = async_values[var_name]
 
         async def async_decorated(*args, **kwargs):
-            return async_values[var_name]
+            await asyncio.sleep(0)
+            return value
 
         async_decorated.__name__ = var_name
         return async_decorated


### PR DESCRIPTION
## Summary

- Add `enabled_events(*args, **kwargs)` method that evaluates `cond`/`unless` guards and returns only events whose conditions are satisfied
- Works with both sync and async engines, forwarding `*args`/`**kwargs` to condition callbacks
- Treats condition exceptions as enabled (permissive — only excludes events we're certain are disabled)
- Add documentation with doctested examples to `docs/guards.md`

Closes #520