### PR TITLE
fix: silence Pyright false positive on transition calls

### DIFF
--- a/statemachine/transition_mixin.py
+++ b/statemachine/transition_mixin.py
@@ -1,14 +1,21 @@
 from typing import Callable
 
 from .callbacks import CallbackGroup
+from .i18n import _
 
 
 class AddCallbacksMixin:
     def _add_callback(self, callback, grouper: CallbackGroup, is_event=False, **kwargs):
         raise NotImplementedError
 
-    def __call__(self, f):
-        return self._add_callback(f, CallbackGroup.ON, is_event=True)
+    def __call__(self, *args, **kwargs):
+        if len(args) == 1 and callable(args[0]) and not kwargs:
+            return self._add_callback(args[0], CallbackGroup.ON, is_event=True)
+        raise TypeError(
+            _("{} only supports the decorator syntax to register callbacks.").format(
+                type(self).__name__
+            )
+        )
 
     def before(self, f: Callable):
         """Adds a ``before`` :ref:`transition actions` callback to every :ref:`transition` in the

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -71,6 +71,20 @@ def test_transition_call_can_only_be_used_as_decorator():
         transition("not a callable")
 
 
+def test_transition_list_call_can_only_be_used_as_decorator():
+    source, dest = State("Source"), State("Destination")
+    transition_list = source.to(dest)
+
+    with pytest.raises(TypeError, match="TransitionList"):
+        transition_list("not a callable")
+
+    with pytest.raises(TypeError, match="TransitionList"):
+        transition_list()
+
+    with pytest.raises(TypeError, match="TransitionList"):
+        transition_list(42, extra="kwarg")
+
+
 @pytest.fixture(params=["bounded", "unbounded"])
 def transition_callback_machine(request):
     if request.param == "bounded":


### PR DESCRIPTION
## Summary
- Changed `AddCallbacksMixin.__call__(self, f)` to `__call__(self, *args, **kwargs)` with runtime validation, silencing Pyright/Pylance false positive about missing parameter `f` when calling events
- Pyright cannot follow the metaclass transformation from `TransitionList` → `Event`, so it reports `sm.event()` as missing the `f` argument
- The decorator syntax (`@transition_list`) continues to work as before
- Added test covering the `TypeError` for invalid call signatures on `TransitionList`

Closes #511