### PR TITLE
fix: skip MachineMixin init for Django historical models

### DIFF
--- a/statemachine/mixins.py
+++ b/statemachine/mixins.py
@@ -22,6 +22,8 @@ class MachineMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not self.state_machine_name:
+            if self._is_django_historical_model():
+                return
             raise ValueError(
                 _("{!r} is not a valid state machine name.").format(self.state_machine_name)
             )
@@ -34,3 +36,12 @@ class MachineMixin:
         )
         if self.bind_events_as_methods:
             sm.bind_events_to(self)
+
+    @classmethod
+    def _is_django_historical_model(cls) -> bool:
+        """Detect Django historical models created by ``apps.get_model()`` in migrations.
+
+        Django sets ``__module__ = '__fake__'`` on these dynamically-created classes,
+        which lack the user-defined class attributes like ``state_machine_name``.
+        """
+        return getattr(cls, "__module__", None) == "__fake__"

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -21,3 +21,18 @@ def test_mixin_should_raise_exception_if_machine_class_does_not_exist():
 
     with pytest.raises(ValueError, match="None is not a valid state machine name"):
         MyModelWithoutMachineName()
+
+
+def test_mixin_should_skip_init_for_django_historical_models():
+    """Regression test for #551: MachineMixin fails in Django data migrations.
+
+    Django's ``apps.get_model()`` returns historical models with ``__module__ = '__fake__'``
+    that don't carry user-defined class attributes like ``state_machine_name``.
+    """
+
+    # Simulate a Django historical model: __module__ is '__fake__' and
+    # state_machine_name is not set (falls back to None from MachineMixin).
+    HistoricalModel = type("HistoricalModel", (MachineMixin,), {"__module__": "__fake__"})
+
+    instance = HistoricalModel()
+    assert not hasattr(instance, "statemachine")


### PR DESCRIPTION
## Summary
- Django's `apps.get_model()` creates historical model classes with `__module__ = '__fake__'` that don't carry user-defined class attributes like `state_machine_name`
- `MachineMixin.__init__` now detects Django historical models and skips state machine initialization instead of raising `ValueError`
- Normal usage is unaffected — the error is still raised when `state_machine_name` is genuinely missing

### Why not `deconstruct`?
Django's migration serializer uses `TypeSerializer` for base classes, which serializes by import path only — it never calls `deconstruct()` on types. That mechanism only applies to field/validator instances.

Closes #551