### PR TITLE
feat: add weighted (probabilistic) transitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,21 @@ uv run pytest -n auto
 
 Coverage is enabled by default.
 
+### Testing both sync and async engines
+
+Use the `sm_runner` fixture (from `tests/conftest.py`) when you need to test the same
+statechart on both sync and async engines. It is parametrized with `["sync", "async"]`
+and provides `start()` / `send()` helpers that handle engine selection automatically:
+
+```python
+async def test_something(self, sm_runner):
+    sm = await sm_runner.start(MyStateChart)
+    await sm_runner.send(sm, "some_event")
+    assert "expected_state" in sm.configuration_values
+```
+
+Do **not** manually add async no-op listeners or duplicate test classes — prefer `sm_runner`.
+
 ## Linting and formatting
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ async
 mixins
 integrations
 diagram
+weighted_transitions
 processing_model
 statecharts
 api

--- a/docs/releases/3.0.0.md
+++ b/docs/releases/3.0.0.md
@@ -346,6 +346,35 @@ flag `validate_disconnected_states: bool = True` that can be used to disable thi
 It's already disabled when parsing SCXML files.
 
 
+### Weighted (probabilistic) transitions
+
+A new contrib module `statemachine.contrib.weighted` provides `weighted_transitions()`,
+enabling probabilistic transition selection based on relative weights. This works entirely
+through the existing condition system — no engine changes required:
+
+```python
+from statemachine.contrib.weighted import weighted_transitions
+
+class GameCharacter(StateChart):
+    standing = State(initial=True)
+    shift_weight = State()
+    adjust_hair = State()
+    bang_shield = State()
+
+    idle = weighted_transitions(
+        standing,
+        (shift_weight, 70),
+        (adjust_hair, 20),
+        (bang_shield, 10),
+        seed=42,
+    )
+
+    finish = shift_weight.to(standing) | adjust_hair.to(standing) | bang_shield.to(standing)
+```
+
+See {ref}`weighted-transitions` for full documentation.
+
+
 ## Bugfixes in 3.0.0
 
 - Fixes [#XXX](https://github.com/fgmacedo/python-statemachine/issues/XXX).

--- a/docs/weighted_transitions.md
+++ b/docs/weighted_transitions.md
@@ -1,0 +1,247 @@
+(weighted-transitions)=
+
+# Weighted transitions
+
+```{versionadded} 3.0.0
+```
+
+The `weighted_transitions` utility lets you define **probabilistic transitions** — where
+each transition from a state has a relative weight that determines how likely it is to be
+selected when the event fires.
+
+This is a contrib module that works entirely through the existing {ref}`guards` system.
+No engine modifications are needed.
+
+## Installation
+
+The module is included in the `python-statemachine` package. Import it from the contrib
+namespace:
+
+```python
+from statemachine.contrib.weighted import weighted_transitions
+
+# Only needed when passing transition kwargs (cond, on, etc.)
+from statemachine.contrib.weighted import to
+```
+
+## Basic usage
+
+Pass a **source state** followed by `(target, weight)` tuples. The result is a regular
+{ref}`TransitionList` that you assign to a class attribute as an event:
+
+```{testsetup}
+
+>>> from statemachine import State, StateChart
+>>> from statemachine.contrib.weighted import to, weighted_transitions
+
+```
+
+```py
+>>> class GameCharacter(StateChart):
+...     standing = State(initial=True)
+...     shift_weight = State()
+...     adjust_hair = State()
+...     bang_shield = State()
+...
+...     idle = weighted_transitions(
+...         standing,
+...         (shift_weight, 70),
+...         (adjust_hair, 20),
+...         (bang_shield, 10),
+...         seed=42,
+...     )
+...
+...     finish = (
+...         shift_weight.to(standing)
+...         | adjust_hair.to(standing)
+...         | bang_shield.to(standing)
+...     )
+
+>>> sm = GameCharacter()
+>>> sm.send("idle")
+>>> any(
+...     s in sm.configuration_values
+...     for s in ("shift_weight", "adjust_hair", "bang_shield")
+... )
+True
+
+```
+
+When `idle` fires, the engine randomly selects one of the three transitions based on
+their relative weights: 70% chance for `shift_weight`, 20% for `adjust_hair`,
+10% for `bang_shield`.
+
+## Weights
+
+Weights can be any **positive number** — integers, floats, or a mix of both. They are
+relative, not absolute percentages:
+
+```python
+# These are equivalent (same 70/20/10 ratio):
+idle = weighted_transitions(
+    standing,
+    (shift_weight, 70),
+    (adjust_hair, 20),
+    (bang_shield, 10),
+)
+
+idle = weighted_transitions(
+    standing,
+    (shift_weight, 7),
+    (adjust_hair, 2),
+    (bang_shield, 1),
+)
+
+idle = weighted_transitions(
+    standing,
+    (shift_weight, 0.7),
+    (adjust_hair, 0.2),
+    (bang_shield, 0.1),
+)
+```
+
+The tuple format `(target, weight)` follows the standard Python pattern used by
+{py:func}`random.choices`.
+
+## Reproducibility with `seed`
+
+Pass a `seed` parameter for deterministic, reproducible sequences — useful for testing:
+
+```python
+go = weighted_transitions(
+    s1,
+    (s2, 50),
+    (s3, 50),
+    seed=42,  # same seed always produces the same sequence
+)
+```
+
+```{note}
+The seed initializes a per-group `random.Random` instance that is shared across all
+instances of the same state machine class. This means the sequence is deterministic
+for a given program execution, but different instances advance the same RNG.
+```
+
+## Per-transition options
+
+Use the {func}`~statemachine.contrib.weighted.to` helper to pass transition keyword
+arguments (``cond``, ``unless``, ``before``, ``on``, ``after``, …) as natural kwargs.
+For simple destinations without extra options, a plain ``(target, weight)`` tuple is
+enough — ``to()`` is only needed when you want to customize the transition:
+
+```py
+>>> class GuardedWeighted(StateChart):
+...     idle = State(initial=True)
+...     walk = State()
+...     run = State()
+...
+...     move = weighted_transitions(
+...         idle,
+...         (walk, 70),
+...         to(run, 30, cond="has_energy"),
+...     )
+...     stop = walk.to(idle) | run.to(idle)
+...
+...     has_energy = True
+
+>>> sm = GuardedWeighted()
+
+```
+
+```{important}
+**No fallback when a guard fails.** If the weighted selection picks a transition whose
+guard evaluates to ``False``, the event fails — the engine does **not** silently fall back
+to another transition. This preserves the probability semantics: a 70/30 split means
+exactly that, not "70/30 unless the 30% is blocked, in which case always 100% for
+the other".
+
+This behavior follows {ref}`conditions` evaluation: the first transition whose **all**
+conditions pass is executed.
+```
+
+## Combining with callbacks
+
+All standard {ref}`actions` work with weighted events — `before`, `on`, `after` callbacks
+and naming conventions like `on_<event>()`:
+
+```python
+class WithCallbacks(StateChart):
+    s1 = State(initial=True)
+    s2 = State()
+    s3 = State()
+
+    go = weighted_transitions(s1, (s2, 60), (s3, 40))
+    back = s2.to(s1) | s3.to(s1)
+
+    def on_go(self):
+        print("go event fired!")
+
+    def after_go(self):
+        print("after go!")
+```
+
+## Multiple independent groups
+
+Each call to `weighted_transitions()` creates an independent weighted group with its
+own RNG. You can have multiple weighted events on the same state machine:
+
+```python
+class MultiGroup(StateChart):
+    idle = State(initial=True)
+    walk = State()
+    run = State()
+    wave = State()
+    bow = State()
+
+    move = weighted_transitions(idle, (walk, 70), (run, 30), seed=1)
+    greet = weighted_transitions(idle, (wave, 80), (bow, 20), seed=2)
+    back = walk.to(idle) | run.to(idle) | wave.to(idle) | bow.to(idle)
+```
+
+The `move` and `greet` events use separate RNGs and don't interfere with each other.
+
+## Validation
+
+`weighted_transitions()` validates inputs at class definition time:
+
+- The first argument must be a `State` (the source).
+- Each destination must be a `(target_state, weight)` or
+  `(target_state, weight, kwargs_dict)` tuple.
+- Weights must be positive numbers (`int` or `float`).
+- At least one destination is required.
+
+```py
+>>> weighted_transitions(State(initial=True))
+Traceback (most recent call last):
+    ...
+ValueError: weighted_transitions() requires at least one (target, weight) destination
+
+>>> s1, s2 = State(initial=True), State()
+>>> weighted_transitions(s1, (s2, -5))
+Traceback (most recent call last):
+    ...
+ValueError: Destination 0: weight must be positive, got -5
+
+>>> weighted_transitions(s1, (s2, "ten"))
+Traceback (most recent call last):
+    ...
+TypeError: Destination 0: weight must be a positive number, got str
+
+```
+
+## How it works
+
+Under the hood, `weighted_transitions()`:
+
+1. Creates a `_WeightedGroup` holding the weights and a `random.Random` instance.
+2. Calls `source.to(target, **kwargs)` for each destination, creating standard
+   transitions.
+3. Attaches a lightweight condition callable to each transition's `cond` list.
+4. When the event fires, the engine evaluates conditions in order. The first condition
+   to run rolls the dice (using `random.choices`) and caches the result. Subsequent
+   conditions check against the cache.
+5. Only the selected transition's condition returns `True` — the engine picks it.
+
+This means weighted transitions are fully compatible with all engine features:
+{ref}`actions`, {ref}`validators-and-guards`, {ref}`listeners`, async engines,
+and {ref}`diagram generation <diagram>`.

--- a/statemachine/contrib/diagram.py
+++ b/statemachine/contrib/diagram.py
@@ -296,12 +296,37 @@ def quickchart_write_svg(sm: StateChart, path: str):
         f.write(data)
 
 
+def _find_sm_class(module):
+    """Find the first StateChart subclass defined in a module."""
+    import inspect
+
+    for _name, obj in inspect.getmembers(module, inspect.isclass):
+        if (
+            issubclass(obj, StateChart)
+            and obj is not StateChart
+            and obj.__module__ == module.__name__
+        ):
+            return obj
+    return None
+
+
 def import_sm(qualname):
     module_name, class_name = qualname.rsplit(".", 1)
     module = importlib.import_module(module_name)
     smclass = getattr(module, class_name, None)
-    if not smclass or not issubclass(smclass, StateChart):
-        raise ValueError(f"{class_name} is not a subclass of StateMachine")
+    if smclass is not None and isinstance(smclass, type) and issubclass(smclass, StateChart):
+        return smclass
+
+    # qualname may be a module path without a class name — try importing
+    # the whole path as a module and find the first StateChart subclass.
+    try:
+        module = importlib.import_module(qualname)
+    except ImportError as err:
+        raise ValueError(f"{class_name} is not a subclass of StateMachine") from err
+
+    smclass = _find_sm_class(module)
+    if smclass is None:
+        raise ValueError(f"No StateMachine subclass found in module {qualname!r}")
 
     return smclass
 

--- a/statemachine/contrib/weighted.py
+++ b/statemachine/contrib/weighted.py
@@ -1,0 +1,193 @@
+import random
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Union
+
+from statemachine.callbacks import CallbackPriority
+from statemachine.transition_list import TransitionList
+
+if TYPE_CHECKING:
+    from statemachine.state import State
+
+
+class _WeightedGroup:
+    """Holds weights and a shared random.Random instance for a group of weighted transitions.
+
+    When the first transition's cond (index 0) is evaluated, it rolls the dice and caches
+    the selected index. Subsequent conds check against the cache.
+    """
+
+    def __init__(self, weights: List[float], seed: "int | float | str | None" = None):
+        self.weights = weights
+        self.rng = random.Random(seed)
+        self._selected: "int | None" = None
+        self._population = list(range(len(weights)))
+
+    def select(self) -> int:
+        """Roll the dice and cache the selected index."""
+        self._selected = self.rng.choices(self._population, weights=self.weights, k=1)[0]
+        return self._selected
+
+    @property
+    def selected(self) -> "int | None":
+        return self._selected
+
+
+def _make_weighted_cond(index: int, group: _WeightedGroup, weight: float, total_weight: float):
+    """Create a weighted condition callable for a specific transition index.
+
+    Returns a function that, when called, returns True only for the selected weighted
+    transition. Index 0 rolls the dice; other indices check against the cached selection.
+    """
+    pct = weight / total_weight * 100
+
+    def weighted_cond() -> bool:
+        if index == 0:
+            selected = group.select()
+        elif group.selected is None:
+            selected = group.select()
+        else:
+            selected = group.selected
+        return selected == index
+
+    weighted_cond.__name__ = f"weight={weight} ({pct:.0f}%)"
+    weighted_cond.__qualname__ = f"_weighted_cond_{index}_{id(group)}"
+    return weighted_cond
+
+
+# Type alias for a weighted destination:
+#   (target, weight)  or  (target, weight, kwargs_dict)
+_WeightedDest = Union[
+    Tuple["State", Union[int, float]],
+    Tuple["State", Union[int, float], Dict[str, Any]],
+]
+
+
+def to(target: "State", weight: "int | float", **kwargs: Any) -> _WeightedDest:
+    """Build a weighted destination with transition keyword arguments.
+
+    Syntactic sugar that returns a ``(target, weight, kwargs)`` tuple, allowing
+    transition options (``cond``, ``unless``, ``before``, ``on``, ``after``, …) to be
+    passed as natural keyword arguments instead of a dict.
+
+    For simple cases without extra options, a plain ``(target, weight)`` tuple works
+    just as well — ``to()`` is only needed when you want to add transition kwargs.
+
+    Args:
+        target: The destination state.
+        weight: A positive number representing the relative weight.
+        **kwargs: Keyword arguments forwarded to ``source.to(target, **kwargs)``.
+
+    Returns:
+        A ``(target, weight, kwargs)`` tuple accepted by :func:`weighted_transitions`.
+
+    Example::
+
+        move = weighted_transitions(
+            standing,
+            to(walk, 70),
+            to(run, 30, cond="has_energy", on="start_running"),
+            seed=42,
+        )
+
+    """
+    return (target, weight, kwargs)
+
+
+def _validate_dest(i: int, item: Any) -> "Tuple[State, float, Dict[str, Any]]":
+    """Validate and normalize a single ``(target, weight[, kwargs])`` tuple."""
+    from statemachine.state import State
+
+    if not isinstance(item, tuple) or len(item) not in (2, 3):
+        raise TypeError(
+            f"Destination {i} must be a (target_state, weight) or "
+            f"(target_state, weight, kwargs) tuple, got {type(item).__name__}"
+        )
+
+    if len(item) == 2:
+        target, weight = item
+        kwargs: Dict[str, Any] = {}
+    else:
+        target, weight, kwargs = item
+        if not isinstance(kwargs, dict):
+            raise TypeError(
+                f"Destination {i}: third element must be a dict of "
+                f"transition kwargs, got {type(kwargs).__name__}"
+            )
+
+    if not isinstance(target, State):
+        raise TypeError(
+            f"Destination {i}: first element must be a State, got {type(target).__name__}"
+        )
+
+    if not isinstance(weight, (int, float)):
+        raise TypeError(
+            f"Destination {i}: weight must be a positive number, got {type(weight).__name__}"
+        )
+    if weight <= 0:
+        raise ValueError(f"Destination {i}: weight must be positive, got {weight}")
+
+    return target, float(weight), kwargs
+
+
+def weighted_transitions(
+    source: "State",
+    *destinations: _WeightedDest,
+    seed: "int | float | str | None" = None,
+) -> TransitionList:
+    """Create a :ref:`TransitionList` where transitions are selected probabilistically
+    based on weights.
+
+    Takes a ``source`` state and one or more ``(target, weight)`` tuples. For simple
+    cases a plain tuple is enough. When you need transition options (``cond``, ``on``,
+    etc.), use the :func:`to` helper to pass them as keyword arguments::
+
+        move = weighted_transitions(
+            standing,
+            (walk, 70),                                  # plain tuple
+            to(run, 30, cond="has_energy", on="sprint"), # with kwargs
+            seed=42,
+        )
+
+    The returned :ref:`TransitionList` can be assigned to a class attribute just like
+    any other event definition. At runtime, the engine evaluates the weighted conditions
+    and selects exactly one transition per event dispatch according to the weight
+    distribution.
+
+    Args:
+        source: The source state for all transitions.
+        *destinations: ``(target, weight)`` tuples or :func:`to` calls.
+        seed: Optional seed for the random number generator (for reproducibility).
+
+    Returns:
+        A :ref:`TransitionList` combining all transitions with weighted conditions.
+
+    """
+    from statemachine.state import State
+
+    if not isinstance(source, State):
+        raise TypeError(f"First argument must be a source State, got {type(source).__name__}")
+
+    if not destinations:
+        raise ValueError(
+            "weighted_transitions() requires at least one (target, weight) destination"
+        )
+
+    validated = [_validate_dest(i, item) for i, item in enumerate(destinations)]
+
+    weights = [w for _, w, _ in validated]
+    total_weight = sum(weights)
+    group = _WeightedGroup(weights, seed=seed)
+
+    result = TransitionList()
+    for index, (target, weight, kwargs) in enumerate(validated):
+        trans = source.to(target, **kwargs)
+        cond_fn = _make_weighted_cond(index, group, weight, total_weight)
+        for transition in trans.transitions:
+            transition.cond.add(cond_fn, priority=CallbackPriority.GENERIC, expected_value=True)
+        result.add_transitions(trans)
+
+    return result

--- a/tests/examples/weighted_idle_machine.py
+++ b/tests/examples/weighted_idle_machine.py
@@ -1,0 +1,41 @@
+"""
+
+------------------------------
+Weighted idle animation machine
+------------------------------
+
+This example demonstrates how to use ``weighted_transitions`` to create probabilistic
+idle animations for a game character. Each time the ``idle`` event fires, the character
+randomly picks an animation based on relative weights.
+
+"""
+
+from statemachine.contrib.weighted import weighted_transitions
+
+from statemachine import State
+from statemachine import StateChart
+
+
+class WeightedIdleMachine(StateChart):
+    """A game character with weighted idle animations.
+
+    When idle, the character randomly picks an animation based on weights:
+    - 70% chance: shift weight from foot to foot
+    - 20% chance: adjust hair
+    - 10% chance: bang shield
+    """
+
+    standing = State(initial=True)
+    shift_weight = State()
+    adjust_hair = State()
+    bang_shield = State()
+
+    idle = weighted_transitions(
+        standing,
+        (shift_weight, 70),
+        (adjust_hair, 20),
+        (bang_shield, 10),
+        seed=42,
+    )
+
+    finish = shift_weight.to(standing) | adjust_hair.to(standing) | bang_shield.to(standing)

--- a/tests/test_contrib_diagram.py
+++ b/tests/test_contrib_diagram.py
@@ -66,6 +66,16 @@ class TestDiagramCmdLine:
             '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n<!DOCTYPE svg'
         )
 
+    def test_generate_image_from_module_path(self, tmp_path):
+        """Accept a module path without the class name and auto-discover the SM class."""
+        out = tmp_path / "sm.svg"
+
+        main(["tests.examples.traffic_light_machine", str(out)])
+
+        assert out.read_text().startswith(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n<!DOCTYPE svg'
+        )
+
     def test_generate_complain_about_bad_sm_path(self, capsys, tmp_path):
         out = tmp_path / "sm.svg"
 
@@ -77,6 +87,13 @@ class TestDiagramCmdLine:
                     str(out),
                 ]
             )
+
+    def test_generate_complain_about_module_without_sm(self, tmp_path):
+        out = tmp_path / "sm.svg"
+
+        expected_error = "No StateMachine subclass found in module"
+        with pytest.raises(ValueError, match=expected_error):
+            main(["tests.examples", str(out)])
 
 
 class TestQuickChart:

--- a/tests/test_weighted_transitions.py
+++ b/tests/test_weighted_transitions.py
@@ -1,0 +1,448 @@
+from collections import Counter
+
+import pytest
+from statemachine.contrib.weighted import _make_weighted_cond
+from statemachine.contrib.weighted import _WeightedGroup
+from statemachine.contrib.weighted import to
+from statemachine.contrib.weighted import weighted_transitions
+
+from statemachine import State
+from statemachine import StateChart
+from statemachine import StateMachine
+
+
+@pytest.fixture()
+def WeightedIdleSC():
+    from tests.examples.weighted_idle_machine import WeightedIdleMachine
+
+    return WeightedIdleMachine
+
+
+class TestWeightedTransitionsBasic:
+    def test_deterministic_with_seed(self, WeightedIdleSC):
+        sm = WeightedIdleSC()
+        sm.send("idle")
+        first_state = sm.current_state
+
+        sm.send("finish")
+        sm.send("idle")
+        second_state = sm.current_state
+
+        # With seed=42, results are deterministic
+        # Create a fresh instance to verify same seed produces same sequence
+        sm2 = WeightedIdleSC()
+        sm2.send("idle")
+        assert sm2.current_state == first_state
+        sm2.send("finish")
+        sm2.send("idle")
+        assert sm2.current_state == second_state
+
+    def test_statistical_distribution(self, WeightedIdleSC):
+        """Over many iterations, the distribution should approximate the weights."""
+        sm = WeightedIdleSC()
+        counts = Counter()
+        iterations = 10000
+
+        for _ in range(iterations):
+            sm.send("idle")
+            counts[sm.current_state.id] += 1
+            sm.send("finish")
+
+        # With 70/20/10 weights, check roughly correct distribution (within 5%)
+        assert abs(counts["shift_weight"] / iterations - 0.70) < 0.05
+        assert abs(counts["adjust_hair"] / iterations - 0.20) < 0.05
+        assert abs(counts["bang_shield"] / iterations - 0.10) < 0.05
+
+    def test_single_weighted_transition(self):
+        class SingleWeighted(StateChart):
+            s1 = State(initial=True)
+            s2 = State()
+
+            go = weighted_transitions(s1, (s2, 100), seed=0)
+            back = s2.to(s1)
+
+        sm = SingleWeighted()
+        sm.send("go")
+        assert sm.current_state == SingleWeighted.s2
+
+    def test_equal_weights(self):
+        class EqualWeights(StateChart):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+
+            go = weighted_transitions(s1, (s2, 50), (s3, 50))
+            back = s2.to(s1) | s3.to(s1)
+
+        sm = EqualWeights()
+        counts = Counter()
+        iterations = 5000
+
+        for _ in range(iterations):
+            sm.send("go")
+            counts[sm.current_state.id] += 1
+            sm.send("back")
+
+        # Should be roughly 50/50 within 5%
+        assert abs(counts["s2"] / iterations - 0.50) < 0.05
+        assert abs(counts["s3"] / iterations - 0.50) < 0.05
+
+    def test_float_weights(self):
+        class FloatWeights(StateChart):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+
+            go = weighted_transitions(s1, (s2, 0.7), (s3, 0.3))
+            back = s2.to(s1) | s3.to(s1)
+
+        sm = FloatWeights()
+        counts = Counter()
+        iterations = 5000
+
+        for _ in range(iterations):
+            sm.send("go")
+            counts[sm.current_state.id] += 1
+            sm.send("back")
+
+        assert abs(counts["s2"] / iterations - 0.70) < 0.05
+        assert abs(counts["s3"] / iterations - 0.30) < 0.05
+
+    def test_mixed_int_and_float_weights(self):
+        class MixedWeights(StateChart):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+
+            go = weighted_transitions(s1, (s2, 10), (s3, 5.5), seed=42)
+            back = s2.to(s1) | s3.to(s1)
+
+        sm = MixedWeights()
+        sm.send("go")
+        assert sm.current_state in (MixedWeights.s2, MixedWeights.s3)
+
+
+class TestWeightedTransitionsWithGuards:
+    def test_with_user_cond_guard(self):
+        class GuardedWeighted(StateChart):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+
+            go = weighted_transitions(
+                s1,
+                to(s2, 50, cond="is_allowed"),
+                (s3, 50),
+                seed=0,
+            )
+            back = s2.to(s1) | s3.to(s1)
+
+            def is_allowed(self):
+                return self.allow_s2
+
+        sm = GuardedWeighted()
+        sm.allow_s2 = True
+
+        # When is_allowed=True, both transitions can fire
+        counts = Counter()
+        for _ in range(1000):
+            sm.send("go")
+            counts[sm.current_state.id] += 1
+            sm.send("back")
+
+        assert counts["s2"] > 0
+        assert counts["s3"] > 0
+
+    def test_with_unless_guard(self):
+        class UnlessWeighted(StateChart):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+
+            go = weighted_transitions(
+                s1,
+                to(s2, 90, unless="is_blocked"),
+                (s3, 10),
+                seed=0,
+            )
+            back = s2.to(s1) | s3.to(s1)
+
+            def is_blocked(self):
+                return self.blocked
+
+        sm = UnlessWeighted()
+        sm.blocked = False
+
+        # When not blocked, s2 can fire
+        sm.send("go")
+        first_state = sm.current_state
+        sm.send("back")
+
+        # When blocked, s2 cond fails even if weight selects it
+        sm.blocked = True
+        results = Counter()
+        for _ in range(100):
+            try:
+                sm.send("go")
+                results[sm.current_state.id] += 1
+                sm.send("back")
+            except Exception:
+                results["failed"] += 1
+
+        # s3 should still work when weight selects it
+        assert results["s3"] > 0
+        assert first_state is not None
+
+    def test_guard_failure_no_fallback(self):
+        """When the selected transition's guard fails, no fallback occurs."""
+
+        class NoFallback(StateMachine):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+
+            go = weighted_transitions(
+                s1,
+                to(s2, 90, cond="allow_s2"),
+                (s3, 10),
+                seed=1,
+            )
+            back = s2.to(s1) | s3.to(s1)
+
+            allow_s2 = True
+
+        sm = NoFallback()
+        sm.allow_s2 = False
+
+        from statemachine.exceptions import TransitionNotAllowed
+
+        got_failure = False
+        for _ in range(50):
+            try:
+                sm.send("go")
+                sm.send("back")
+            except TransitionNotAllowed:
+                got_failure = True
+                break
+
+        assert got_failure, "Expected TransitionNotAllowed when guard blocks selection"
+
+
+class TestWeightedTransitionsValidation:
+    def test_empty_destinations(self):
+        s1 = State(initial=True)
+        with pytest.raises(ValueError, match="requires at least one"):
+            weighted_transitions(s1)
+
+    def test_source_not_a_state(self):
+        with pytest.raises(TypeError, match="First argument must be a source State"):
+            weighted_transitions("not_a_state", ("target", 10))  # type: ignore[arg-type]
+
+    def test_not_a_tuple(self):
+        s1 = State(initial=True)
+        with pytest.raises(TypeError, match="must be a .* tuple"):
+            weighted_transitions(s1, "not a tuple")  # type: ignore[arg-type]
+
+    def test_wrong_tuple_length(self):
+        s1 = State(initial=True)
+        with pytest.raises(TypeError, match="must be a .* tuple"):
+            weighted_transitions(s1, (1, 2, 3, 4))  # type: ignore[arg-type]
+
+    def test_target_not_a_state(self):
+        s1 = State(initial=True)
+        with pytest.raises(TypeError, match="first element must be a State"):
+            weighted_transitions(s1, ("not_a_state", 10))  # type: ignore[arg-type]
+
+    def test_weight_not_a_number(self):
+        s1 = State(initial=True)
+        s2 = State()
+        with pytest.raises(TypeError, match="weight must be a positive number"):
+            weighted_transitions(s1, (s2, "ten"))  # type: ignore[arg-type]
+
+    def test_weight_zero(self):
+        s1 = State(initial=True)
+        s2 = State()
+        with pytest.raises(ValueError, match="weight must be positive"):
+            weighted_transitions(s1, (s2, 0))
+
+    def test_weight_negative(self):
+        s1 = State(initial=True)
+        s2 = State()
+        with pytest.raises(ValueError, match="weight must be positive"):
+            weighted_transitions(s1, (s2, -5))
+
+    def test_kwargs_not_a_dict(self):
+        s1 = State(initial=True)
+        s2 = State()
+        with pytest.raises(TypeError, match="third element must be a dict"):
+            weighted_transitions(s1, (s2, 10, "bad"))  # type: ignore[arg-type]
+
+    def test_kwargs_forwarded_to_transition(self):
+        """Verify that kwargs dict is forwarded to source.to()."""
+
+        class WithKwargs(StateChart):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+
+            go = weighted_transitions(
+                s1,
+                (s2, 50, {"on": "do_something"}),
+                (s3, 50),
+                seed=42,
+            )
+            back = s2.to(s1) | s3.to(s1)
+
+            def __init__(self):
+                self.log = []
+                super().__init__()
+
+            def do_something(self):
+                self.log.append("did_it")
+
+        sm = WithKwargs()
+        # Run enough iterations that s2 is selected at least once
+        for _ in range(50):
+            sm.send("go")
+            sm.send("back")
+
+        assert "did_it" in sm.log
+
+    def test_to_helper_forwards_kwargs(self):
+        """Verify that to() helper passes kwargs to source.to()."""
+
+        class WithTo(StateChart):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+
+            go = weighted_transitions(
+                s1,
+                to(s2, 50, on="do_something"),
+                to(s3, 50),
+                seed=42,
+            )
+            back = s2.to(s1) | s3.to(s1)
+
+            def __init__(self):
+                self.log = []
+                super().__init__()
+
+            def do_something(self):
+                self.log.append("did_it")
+
+        sm = WithTo()
+        for _ in range(50):
+            sm.send("go")
+            sm.send("back")
+
+        assert "did_it" in sm.log
+
+    def test_to_returns_tuple(self):
+        """to() returns a plain tuple compatible with weighted_transitions."""
+        s2 = State()
+
+        result = to(s2, 70)
+        assert isinstance(result, tuple)
+        assert result == (s2, 70, {})
+
+        result_with_kwargs = to(s2, 30, cond="is_ready", on="go")
+        assert isinstance(result_with_kwargs, tuple)
+        assert result_with_kwargs == (s2, 30, {"cond": "is_ready", "on": "go"})
+
+
+class TestWeightedTransitionsWithCallbacks:
+    def test_action_decorators_on_weighted_event(self):
+        """Transition callbacks (before/on/after) work with weighted transitions."""
+
+        class WithCallbacks(StateChart):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+
+            go = weighted_transitions(s1, (s2, 50), (s3, 50), seed=42)
+            back = s2.to(s1) | s3.to(s1)
+
+            def __init__(self):
+                self.log = []
+                super().__init__()
+
+            def on_go(self):
+                self.log.append("on_go")
+
+            def after_go(self):
+                self.log.append("after_go")
+
+        sm = WithCallbacks()
+        sm.send("go")
+        assert "on_go" in sm.log
+        assert "after_go" in sm.log
+
+
+class TestWeightedTransitionsEngines:
+    async def test_sync_and_async_engines(self, sm_runner):
+        class WeightedSC(StateChart):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+
+            go = weighted_transitions(s1, (s2, 70), (s3, 30), seed=42)
+            back = s2.to(s1) | s3.to(s1)
+
+        sm = await sm_runner.start(WeightedSC)
+        await sm_runner.send(sm, "go")
+        assert "s2" in sm.configuration_values or "s3" in sm.configuration_values
+        await sm_runner.send(sm, "back")
+        assert "s1" in sm.configuration_values
+
+    async def test_works_with_state_machine(self, sm_runner):
+        class WeightedSM(StateMachine):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+
+            go = weighted_transitions(s1, (s2, 70), (s3, 30), seed=42)
+            back = s2.to(s1) | s3.to(s1)
+
+        sm = await sm_runner.start(WeightedSM)
+        await sm_runner.send(sm, "go")
+        assert "s2" in sm.configuration_values or "s3" in sm.configuration_values
+        await sm_runner.send(sm, "back")
+        assert "s1" in sm.configuration_values
+
+
+class TestMultipleWeightedGroups:
+    def test_independent_groups(self):
+        class MultiGroup(StateChart):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+            s4 = State()
+            s5 = State()
+
+            go_a = weighted_transitions(s1, (s2, 80), (s3, 20), seed=42)
+            go_b = weighted_transitions(s1, (s4, 30), (s5, 70), seed=99)
+            back = s2.to(s1) | s3.to(s1) | s4.to(s1) | s5.to(s1)
+
+        sm = MultiGroup()
+
+        sm.send("go_a")
+        state_a = sm.current_state
+        assert state_a in (MultiGroup.s2, MultiGroup.s3)
+        sm.send("back")
+
+        sm.send("go_b")
+        state_b = sm.current_state
+        assert state_b in (MultiGroup.s4, MultiGroup.s5)
+
+
+class TestWeightedCondRepr:
+    def test_cond_name_includes_weight_and_percentage(self):
+        group = _WeightedGroup([70, 20, 10])
+        cond = _make_weighted_cond(0, group, 70.0, 100.0)
+        assert cond.__name__ == "weight=70.0 (70%)"
+
+    def test_cond_name_with_fractional_percentage(self):
+        group = _WeightedGroup([1, 2])
+        cond = _make_weighted_cond(0, group, 1.0, 3.0)
+        assert cond.__name__ == "weight=1.0 (33%)"

--- a/tests/test_weighted_transitions.py
+++ b/tests/test_weighted_transitions.py
@@ -446,3 +446,13 @@ class TestWeightedCondRepr:
         group = _WeightedGroup([1, 2])
         cond = _make_weighted_cond(0, group, 1.0, 3.0)
         assert cond.__name__ == "weight=1.0 (33%)"
+
+    def test_non_zero_index_cond_rolls_dice_if_not_yet_selected(self):
+        """When a non-zero index cond is evaluated before index 0, it rolls the dice."""
+        group = _WeightedGroup([50, 50], seed=42)
+        cond_1 = _make_weighted_cond(1, group, 50.0, 100.0)
+
+        assert group.selected is None
+        result = cond_1()
+        assert group.selected is not None  # dice was rolled
+        assert result == (group.selected == 1)


### PR DESCRIPTION
## Summary

- Add `weighted_transitions()` contrib utility for probabilistic transition selection based on relative weights — works entirely through the existing `cond` guard system with zero engine changes
- Add `to()` helper for ergonomic per-transition kwargs (`cond`, `on`, `before`, etc.) alongside plain `(target, weight)` tuples
- Fix diagram CLI to accept module-only paths (auto-discovers the SM class in the module)

### API

```python
from statemachine.contrib.weighted import weighted_transitions, to

class GameCharacter(StateChart):
    standing = State(initial=True)
    shift_weight = State()
    adjust_hair = State()
    bang_shield = State()

    idle = weighted_transitions(
        standing,
        (shift_weight, 70),
        (adjust_hair, 20),
        (bang_shield, 10),
        seed=42,
    )

    # With per-transition options via to() helper:
    move = weighted_transitions(
        standing,
        (walk, 70),
        to(run, 30, cond="has_energy", on="sprint"),
        seed=42,
    )
```

### Acknowledgement

Thanks to @bcorfman for the original idea and use case in #539 — this implementation takes a different approach (contrib module using the existing guard system instead of engine changes) but was directly inspired by that PR.