### PR TITLE
refactor!: modernize codebase for v3 — remove deprecated APIs, migrate tests to StateChart

### DIFF
--- a/docs/releases/3.0.0.md
+++ b/docs/releases/3.0.0.md
@@ -486,3 +486,20 @@ The `allow_event_without_transition` was previously configured as an init parame
 attribute.
 
 Defaults to `False` in `StateMachine` class to preserve maximum backwards compatibility.
+
+
+### `States.from_enum` default `use_enum_instance=True`
+
+The `use_enum_instance` parameter of `States.from_enum` now defaults to `True` (was `False` in 2.x).
+This means state values are the enum instances themselves, not their raw values.
+
+If your code relies on raw enum values (e.g., integers), pass `use_enum_instance=False` explicitly.
+
+
+### Short registry names removed
+
+State machine classes are now only registered by their fully-qualified name (`qualname`).
+The short-name lookup (by `cls.__name__`) that was deprecated since v0.8 has been removed.
+
+If you use `get_machine_cls()` (e.g., via `MachineMixin`), make sure you pass the fully-qualified
+dotted path.

--- a/docs/releases/3.0.0.md
+++ b/docs/releases/3.0.0.md
@@ -468,10 +468,9 @@ def on_validate(self, previous_configuration):
 ```
 
 
-### `add_observer()` renamed to `add_listener()`
+### `add_observer()` removed
 
-The method `add_observer` has been renamed to `add_listener`. The old name still works but emits
-a `DeprecationWarning`.
+The method `add_observer`, deprecated since v2.3.2, has been removed. Use `add_listener` instead.
 
 
 ### `TransitionNotAllowed` exception changes

--- a/docs/releases/upgrade_2x_to_3.md
+++ b/docs/releases/upgrade_2x_to_3.md
@@ -159,8 +159,7 @@ while not sm.is_terminated:
 
 ## Replace `add_observer()` with `add_listener()`
 
-The method `add_observer` has been renamed to `add_listener`. The old name still works but emits
-a `DeprecationWarning`.
+The method `add_observer` has been removed in v3.0. Use `add_listener` instead.
 
 **Before (2.x):**
 

--- a/docs/releases/upgrade_2x_to_3.md
+++ b/docs/releases/upgrade_2x_to_3.md
@@ -17,6 +17,8 @@ defaults. Review this guide to understand what changed and adopt the new APIs at
 5. Replace `sm.add_observer(...)` with `sm.add_listener(...)`.
 6. Update code that catches `TransitionNotAllowed` and accesses `.state` → use `.configuration`.
 7. Review `on` callbacks that query `is_active` or `current_state` during transitions.
+8. If using `States.from_enum`, note that `use_enum_instance` now defaults to `True`.
+9. If using `get_machine_cls()` with short names, switch to fully-qualified names.
 
 ---
 
@@ -171,6 +173,51 @@ sm.add_observer(my_listener)
 
 ```python
 sm.add_listener(my_listener)
+```
+
+
+## `States.from_enum` default changed to `use_enum_instance=True`
+
+In 2.x, `States.from_enum` defaulted to `use_enum_instance=False`, meaning state values were the
+raw enum values (e.g., integers). In 3.0, the default is `True`, so state values are the enum
+instances themselves.
+
+**Before (2.x):**
+
+```python
+states = States.from_enum(MyEnum, initial=MyEnum.start)
+# states.start.value == 1  (raw value)
+```
+
+**After (3.0):**
+
+```python
+states = States.from_enum(MyEnum, initial=MyEnum.start)
+# states.start.value == MyEnum.start  (enum instance)
+```
+
+If your code relies on raw enum values, pass `use_enum_instance=False` explicitly.
+
+
+## Short registry names removed
+
+In 2.x, state machine classes were registered both by their fully-qualified name and their short
+class name. The short-name lookup was deprecated since v0.8 and has been removed in 3.0.
+
+**Before (2.x):**
+
+```python
+from statemachine.registry import get_machine_cls
+
+cls = get_machine_cls("MyMachine")  # short name — worked with warning
+```
+
+**After (3.0):**
+
+```python
+from statemachine.registry import get_machine_cls
+
+cls = get_machine_cls("myapp.machines.MyMachine")  # fully-qualified name
 ```
 
 

--- a/statemachine/registry.py
+++ b/statemachine/registry.py
@@ -1,5 +1,3 @@
-import warnings
-
 from .utils import qualname
 
 try:
@@ -16,18 +14,11 @@ _initialized = False
 
 def register(cls):
     _REGISTRY[qualname(cls)] = cls
-    _REGISTRY[cls.__name__] = cls
     return cls
 
 
 def get_machine_cls(name):
     init_registry()
-    if "." not in name:
-        warnings.warn(
-            """Use fully qualified names (<module>.<class>) for state machine mixins.""",
-            DeprecationWarning,
-            stacklevel=2,
-        )
     return _REGISTRY[name]
 
 

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -243,15 +243,6 @@ class StateChart(metaclass=StateMachineMetaclass):
 
         self._callbacks.async_or_sync()
 
-    def add_observer(self, *observers):
-        """Add a listener."""
-        warnings.warn(
-            """Method `add_observer` has been renamed to `add_listener`.""",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.add_listener(*observers)
-
     def add_listener(self, *listeners):
         """Add a listener.
 

--- a/statemachine/states.py
+++ b/statemachine/states.py
@@ -83,7 +83,7 @@ class States:
         return self._states.items()
 
     @classmethod
-    def from_enum(cls, enum_type: EnumType, initial, final=None, use_enum_instance: bool = False):
+    def from_enum(cls, enum_type: EnumType, initial, final=None, use_enum_instance: bool = True):
         """
         Creates a new instance of the ``States`` class from an enumeration.
 
@@ -93,10 +93,10 @@ class States:
         ...     pending = 1
         ...     completed = 2
 
-        A :ref:`StateMachine` that uses this enum can be declared as follows:
+        A :ref:`StateChart` that uses this enum can be declared as follows:
 
-        >>> from statemachine import StateMachine
-        >>> class ApprovalMachine(StateMachine):
+        >>> from statemachine import StateChart
+        >>> class ApprovalMachine(StateChart):
         ...
         ...     _ = States.from_enum(Status, initial=Status.pending, final=Status.completed)
         ...
@@ -107,7 +107,7 @@ class States:
 
         .. tip::
             When you assign the result of ``States.from_enum`` to a class-level variable in your
-            :ref:`StateMachine`, you're all set. You can use any name for this variable. In this
+            :ref:`StateChart`, you're all set. You can use any name for this variable. In this
             example, we used ``_`` to show that the name doesn't matter. The metaclass will inspect
             the variable of type :ref:`States (class)` and automatically assign the inner
             :ref:`State` instances to the state machine.
@@ -128,25 +128,25 @@ class States:
         True
 
         >>> sm.current_state_value
-        2
-
-        If you need to use the enum instance as the state value, you can set the
-        ``use_enum_instance=True``:
-
-        >>> states = States.from_enum(Status, initial=Status.pending, use_enum_instance=True)
-        >>> states.completed.value
         <Status.completed: 2>
 
-        .. deprecated:: 2.3.3
+        If you need to use the raw enum value instead of the enum instance, you can set
+        ``use_enum_instance=False``:
 
-            On the next major release, ``use_enum_instance=True`` will be the default.
+        >>> states = States.from_enum(Status, initial=Status.pending, use_enum_instance=False)
+        >>> states.completed.value
+        2
+
+        .. versionchanged:: 3.0.0
+
+            The default changed from ``False`` to ``True``.
 
         Args:
             enum_type: An enumeration containing the states of the machine.
             initial: The initial state of the machine.
             final: A set of final states of the machine.
             use_enum_instance: If ``True``, the value of the state will be the enum item instance,
-                otherwise the enum item value. Defaults to ``False``.
+                otherwise the enum item value. Defaults to ``True``.
 
         Returns:
             A new instance of the :ref:`States (class)`.

--- a/statemachine/states.py
+++ b/statemachine/states.py
@@ -12,13 +12,13 @@ class States:
     """
     A class representing a collection of :ref:`State` objects.
 
-    Helps creating :ref:`StateMachine`'s :ref:`state` definitions from other
+    Helps creating :ref:`StateChart`'s :ref:`state` definitions from other
     sources, like an ``Enum`` class, using :meth:`States.from_enum`.
 
     >>> states_def = [('open', {'initial': True}), ('closed', {'final': True})]
 
-    >>> from statemachine import StateMachine
-    >>> class SM(StateMachine):
+    >>> from statemachine import StateChart
+    >>> class SM(StateChart):
     ...
     ...     states = States({
     ...         name: State(**params) for name, params in states_def
@@ -30,8 +30,8 @@ class States:
 
     >>> sm = SM()
     >>> sm.send("close")
-    >>> sm.current_state.id
-    'closed'
+    >>> sm.closed.is_active
+    True
 
     """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,9 +27,9 @@ def current_time():
 def campaign_machine():
     "Define a new class for each test"
     from statemachine import State
-    from statemachine import StateMachine
+    from statemachine import StateChart
 
-    class CampaignMachine(StateMachine):
+    class CampaignMachine(StateChart):
         "A workflow machine"
 
         draft = State(initial=True)
@@ -47,10 +47,12 @@ def campaign_machine():
 def campaign_machine_with_validator():
     "Define a new class for each test"
     from statemachine import State
-    from statemachine import StateMachine
+    from statemachine import StateChart
 
-    class CampaignMachine(StateMachine):
+    class CampaignMachine(StateChart):
         "A workflow machine"
+
+        error_on_execution = False
 
         draft = State(initial=True)
         producing = State("Being produced")
@@ -71,9 +73,9 @@ def campaign_machine_with_validator():
 def campaign_machine_with_final_state():
     "Define a new class for each test"
     from statemachine import State
-    from statemachine import StateMachine
+    from statemachine import StateChart
 
-    class CampaignMachine(StateMachine):
+    class CampaignMachine(StateChart):
         "A workflow machine"
 
         draft = State(initial=True)
@@ -91,9 +93,9 @@ def campaign_machine_with_final_state():
 def campaign_machine_with_values():
     "Define a new class for each test"
     from statemachine import State
-    from statemachine import StateMachine
+    from statemachine import StateChart
 
-    class CampaignMachineWithKeys(StateMachine):
+    class CampaignMachineWithKeys(StateChart):
         "A workflow machine"
 
         draft = State(initial=True, value=1)
@@ -131,9 +133,9 @@ def AllActionsMachine():
 @pytest.fixture()
 def classic_traffic_light_machine(engine):
     from statemachine import State
-    from statemachine import StateMachine
+    from statemachine import StateChart
 
-    class TrafficLightMachine(StateMachine):
+    class TrafficLightMachine(StateChart):
         green = State(initial=True)
         yellow = State()
         red = State()
@@ -150,18 +152,16 @@ def classic_traffic_light_machine(engine):
 
 @pytest.fixture()
 def classic_traffic_light_machine_allow_event(classic_traffic_light_machine):
-    class TrafficLightMachineAllowingEventWithoutTransition(classic_traffic_light_machine):
-        allow_event_without_transition = True
-
-    return TrafficLightMachineAllowingEventWithoutTransition
+    """Already allow_event_without_transition=True (StateChart default)."""
+    return classic_traffic_light_machine
 
 
 @pytest.fixture()
 def reverse_traffic_light_machine():
     from statemachine import State
-    from statemachine import StateMachine
+    from statemachine import StateChart
 
-    class ReverseTrafficLightMachine(StateMachine):
+    class ReverseTrafficLightMachine(StateChart):
         "A traffic light machine"
 
         green = State(initial=True)
@@ -177,9 +177,9 @@ def reverse_traffic_light_machine():
 @pytest.fixture()
 def approval_machine(current_time):  # noqa: C901
     from statemachine import State
-    from statemachine import StateMachine
+    from statemachine import StateChart
 
-    class ApprovalMachine(StateMachine):
+    class ApprovalMachine(StateChart):
         "A workflow machine"
 
         requested = State(initial=True)

--- a/tests/django_project/workflow/statemachines.py
+++ b/tests/django_project/workflow/statemachines.py
@@ -1,11 +1,13 @@
 from statemachine.states import States
 
-from statemachine import StateMachine
+from statemachine import StateChart
 
 from .models import WorkflowSteps
 
 
-class WorfklowStateMachine(StateMachine):
+class WorfklowStateMachine(StateChart):
+    allow_event_without_transition = False
+
     _ = States.from_enum(WorkflowSteps, initial=WorkflowSteps.DRAFT, final=WorkflowSteps.PUBLISHED)
 
     publish = _.DRAFT.to(_.PUBLISHED, cond="is_active")

--- a/tests/examples/enum_campaign_machine.py
+++ b/tests/examples/enum_campaign_machine.py
@@ -27,7 +27,6 @@ class CampaignMachine(StateChart):
         CampaignStatus,
         initial=CampaignStatus.DRAFT,
         final=CampaignStatus.CLOSED,
-        use_enum_instance=True,
     )
 
     add_job = states.DRAFT.to(states.DRAFT) | states.PRODUCING.to(states.PRODUCING)

--- a/tests/examples/statechart_error_handling_machine.py
+++ b/tests/examples/statechart_error_handling_machine.py
@@ -78,16 +78,16 @@ assert "safe" in sm.configuration_values
 
 
 # %%
-# Comparison with StateMachine (error propagation)
-# --------------------------------------------------
+# Comparison with error_on_execution=False (error propagation)
+# --------------------------------------------------------------
 #
-# With ``StateMachine`` (where ``error_on_execution=False``), the same error
+# With ``error_on_execution=False``, the same error
 # would propagate as an exception instead of being caught.
 
-from statemachine import StateMachine  # noqa: E402
 
+class QuestNoCatch(StateChart):
+    error_on_execution = False
 
-class QuestNoCatch(StateMachine):
     safe = State("Safe", initial=True)
     danger_zone = State("Danger Zone")
 

--- a/tests/scxml/test_microwave.py
+++ b/tests/scxml/test_microwave.py
@@ -40,7 +40,7 @@ def test_microwave_scxml():
     processor.parse_scxml("microwave", MICROWAVE_SCXML)
     sm = processor.start()
 
-    assert sm.current_state.id == "unplugged"
+    assert "unplugged" in sm.current_state_value
     sm.send("plug-in")
 
     assert "idle" in sm.current_state_value

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -6,12 +6,13 @@ from statemachine.exceptions import InvalidStateValue
 
 from statemachine import State
 from statemachine import StateChart
-from statemachine import StateMachine
 
 
 @pytest.fixture()
 def async_order_control_machine():  # noqa: C901
-    class OrderControl(StateMachine):
+    class OrderControl(StateChart):
+        allow_event_without_transition = False
+
         waiting_for_payment = State(initial=True)
         processing = State()
         shipping = State()
@@ -98,8 +99,10 @@ def test_async_state_from_sync_context(async_order_control_machine):
     assert sm.completed.is_active
 
 
-class AsyncConditionExpressionMachine(StateMachine):
+class AsyncConditionExpressionMachine(StateChart):
     """Regression test for issue #535: async conditions in boolean expressions."""
+
+    allow_event_without_transition = False
 
     s1 = State(initial=True)
 
@@ -190,17 +193,21 @@ async def test_async_state_should_be_initialized(async_order_control_machine):
     """
 
     sm = async_order_control_machine()
-    with pytest.raises(
-        InvalidStateValue,
-        match=re.escape(
-            r"There's no current state set. In async code, "
-            r"did you activate the initial state? (e.g., `await sm.activate_initial_state()`)"
-        ),
-    ):
-        assert sm.current_state == sm.waiting_for_payment
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        with pytest.raises(
+            InvalidStateValue,
+            match=re.escape(
+                r"There's no current state set. In async code, "
+                r"did you activate the initial state? (e.g., `await sm.activate_initial_state()`)"
+            ),
+        ):
+            sm.current_state  # noqa: B018
 
     await sm.activate_initial_state()
-    assert sm.current_state == sm.waiting_for_payment
+    assert sm.waiting_for_payment.is_active
 
 
 @pytest.mark.timeout(5)
@@ -303,7 +310,9 @@ async def test_async_invalid_definition_in_after_propagates():
 async def test_async_runtime_error_in_after_without_error_on_execution():
     """RuntimeError in async after callback without error_on_execution propagates."""
 
-    class SM(StateMachine):
+    class SM(StateChart):
+        error_on_execution = False
+
         s1 = State(initial=True)
         s2 = State(final=True)
 
@@ -384,7 +393,9 @@ async def test_async_engine_invalid_definition_in_after_propagates():
 async def test_async_engine_runtime_error_in_after_without_error_on_execution_propagates():
     """AsyncEngine: RuntimeError in async after callback without error_on_execution raises."""
 
-    class SM(StateMachine):
+    class SM(StateChart):
+        error_on_execution = False
+
         s1 = State(initial=True)
         s2 = State(final=True)
 
@@ -403,7 +414,7 @@ async def test_async_engine_runtime_error_in_after_without_error_on_execution_pr
 async def test_async_engine_start_noop_when_already_initialized():
     """BaseEngine.start() is a no-op when state machine is already initialized."""
 
-    class SM(StateMachine):
+    class SM(StateChart):
         s1 = State(initial=True)
         s2 = State(final=True)
 
@@ -422,7 +433,7 @@ async def test_async_engine_start_noop_when_already_initialized():
 
 class TestAsyncEnabledEvents:
     async def test_passing_async_condition(self):
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State(final=True)
 
@@ -436,7 +447,7 @@ class TestAsyncEnabledEvents:
         assert [e.id for e in await sm.enabled_events()] == ["go"]
 
     async def test_failing_async_condition(self):
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State(final=True)
 
@@ -450,7 +461,7 @@ class TestAsyncEnabledEvents:
         assert await sm.enabled_events() == []
 
     async def test_kwargs_forwarded_to_async_conditions(self):
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State(final=True)
 
@@ -465,7 +476,7 @@ class TestAsyncEnabledEvents:
         assert [e.id for e in await sm.enabled_events(value=20)] == ["go"]
 
     async def test_async_condition_exception_treated_as_enabled(self):
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State(final=True)
 
@@ -481,7 +492,7 @@ class TestAsyncEnabledEvents:
     async def test_duplicate_event_across_transitions_deduplicated(self):
         """Same event on multiple passing transitions appears only once."""
 
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State()
             s2 = State(final=True)
@@ -501,7 +512,7 @@ class TestAsyncEnabledEvents:
         assert len(ids) == 1
 
     async def test_mixed_enabled_and_disabled_async(self):
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State()
             s2 = State(final=True)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -9,7 +9,7 @@ from statemachine.dispatcher import resolver_factory_from_objects
 from statemachine.exceptions import InvalidDefinition
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 
 
 @pytest.fixture()
@@ -166,7 +166,7 @@ class TestCallbacksAsDecorator:
         assert race_uppercase("Hobbit") == "HOBBIT"
 
     def test_decorate_unbounded_machine_methods(self):
-        class MiniHeroJourneyMachine(StateMachine, strict_states=False):
+        class MiniHeroJourneyMachine(StateChart, strict_states=False):
             ordinary_world = State(initial=True)
             call_to_adventure = State(final=True)
             refusal_of_call = State(final=True)
@@ -222,7 +222,7 @@ class TestIssue406:
     def test_issue_406(self, mocker):
         mock = mocker.Mock()
 
-        class ExampleStateMachine(StateMachine, strict_states=False):
+        class ExampleStateMachine(StateChart, strict_states=False):
             created = State(initial=True)
             inited = State(final=True)
 
@@ -277,7 +277,10 @@ class TestIssue417:
 
     @pytest.fixture()
     def sm_class(self, model_class, mock_calls):
-        class ExampleStateMachine(StateMachine):
+        class ExampleStateMachine(StateChart):
+            allow_event_without_transition = False
+            error_on_execution = False
+
             created = State(initial=True)
             started = State(final=True)
 
@@ -336,7 +339,9 @@ class TestIssue417:
             def this_cannot_resolve(self) -> bool:
                 return True
 
-        class ExampleStateMachine(StateMachine):
+        class ExampleStateMachine(StateChart):
+            error_on_execution = False
+
             created = State(initial=True)
             started = State(final=True)
             start = created.to(started, cond=[StrangeObject.this_cannot_resolve])

--- a/tests/test_callbacks_isolation.py
+++ b/tests/test_callbacks_isolation.py
@@ -1,12 +1,12 @@
 import pytest
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 
 
 @pytest.fixture()
 def simple_sm_cls():
-    class TestStateMachine(StateMachine):
+    class TestStateMachine(StateChart):
         allow_event_without_transition = True
 
         # States

--- a/tests/test_conditions_algebra.py
+++ b/tests/test_conditions_algebra.py
@@ -2,10 +2,13 @@ import pytest
 from statemachine.exceptions import InvalidDefinition
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 
 
-class AnyConditionSM(StateMachine):
+class AnyConditionSM(StateChart):
+    allow_event_without_transition = False
+    error_on_execution = False
+
     start = State(initial=True)
     end = State(final=True)
 
@@ -20,25 +23,25 @@ def test_conditions_algebra_any_false():
     with pytest.raises(sm.TransitionNotAllowed):
         sm.submit()
 
-    assert sm.current_state == sm.start
+    assert sm.start.is_active
 
 
 def test_conditions_algebra_any_left_true():
     sm = AnyConditionSM()
     sm.used_money = True
     sm.submit()
-    assert sm.current_state == sm.end
+    assert sm.end.is_active
 
 
 def test_conditions_algebra_any_right_true():
     sm = AnyConditionSM()
     sm.used_credit = True
     sm.submit()
-    assert sm.current_state == sm.end
+    assert sm.end.is_active
 
 
 def test_should_raise_invalid_definition_if_cond_is_not_valid_sintax():
-    class AnyConditionSM(StateMachine):
+    class AnyConditionSM(StateChart):
         start = State(initial=True)
         end = State(final=True)
 
@@ -52,7 +55,7 @@ def test_should_raise_invalid_definition_if_cond_is_not_valid_sintax():
 
 
 def test_should_raise_invalid_definition_if_cond_is_not_found():
-    class AnyConditionSM(StateMachine):
+    class AnyConditionSM(StateChart):
         start = State(initial=True)
         end = State(final=True)
 

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -9,7 +9,7 @@ import pytest
 from statemachine.states import States
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ class GameStates(str, Enum):
     GAME_END = auto()
 
 
-class GameStateMachine(StateMachine):
+class GameStateMachine(StateChart):
     s = States.from_enum(GameStates, initial=GameStates.GAME_START)
 
     play = s.GAME_START.to(s.GAME_PLAYING)
@@ -44,7 +44,7 @@ class GameStateMachine(StateMachine):
     advance_round = end_game | s.TURN_END.to(s.GAME_END)
 
 
-class MyStateMachine(StateMachine):
+class MyStateMachine(StateChart):
     created = State(initial=True)
     started = State()
 
@@ -56,7 +56,7 @@ class MyStateMachine(StateMachine):
         self.value = [1, 2, 3]
 
 
-class MySM(StateMachine):
+class MySM(StateChart):
     draft = State("Draft", initial=True, value="draft")
     published = State("Published", value="published", final=True)
 
@@ -89,11 +89,11 @@ def test_copy(copy_method):
 
     assert sm.model is not sm2.model
     assert sm.model.name == sm2.model.name
-    assert sm2.current_state == sm.current_state
+    assert sm2.draft.is_active
 
     sm2.model.let_me_be_visible = True
     sm2.send("publish")
-    assert sm2.current_state == sm.published
+    assert sm2.published.is_active
 
 
 def test_copy_with_listeners(copy_method):
@@ -120,16 +120,16 @@ def test_copy_with_listeners(copy_method):
         listener.let_me_be_visible = True
 
     sm2.send("publish")
-    assert sm2.current_state == sm1.published
+    assert sm2.published.is_active
 
 
 def test_copy_with_enum(copy_method):
     sm = GameStateMachine()
     sm.play()
-    assert sm.current_state == GameStateMachine.GAME_PLAYING
+    assert sm.GAME_PLAYING.is_active
 
     sm2 = copy_method(sm)
-    assert sm2.current_state == GameStateMachine.GAME_PLAYING
+    assert sm2.GAME_PLAYING.is_active
 
 
 def test_copy_with_custom_init_and_vars(copy_method):
@@ -139,10 +139,10 @@ def test_copy_with_custom_init_and_vars(copy_method):
     sm2 = copy_method(sm)
     assert sm2.custom == 1
     assert sm2.value == [1, 2, 3]
-    assert sm2.current_state == MyStateMachine.started
+    assert sm2.started.is_active
 
 
-class AsyncTrafficLightMachine(StateMachine):
+class AsyncTrafficLightMachine(StateChart):
     green = State(initial=True)
     yellow = State()
     red = State()
@@ -164,9 +164,9 @@ def test_copy_async_statemachine_before_activation(copy_method):
 
     async def verify():
         await sm_copy.activate_initial_state()
-        assert sm_copy.current_state == AsyncTrafficLightMachine.green
+        assert sm_copy.green.is_active
         await sm_copy.cycle()
-        assert sm_copy.current_state == AsyncTrafficLightMachine.yellow
+        assert sm_copy.yellow.is_active
 
     asyncio.run(verify())
 
@@ -178,13 +178,13 @@ def test_copy_async_statemachine_after_activation(copy_method):
         sm = AsyncTrafficLightMachine()
         await sm.activate_initial_state()
         await sm.cycle()
-        assert sm.current_state == AsyncTrafficLightMachine.yellow
+        assert sm.yellow.is_active
 
         sm_copy = copy_method(sm)
 
         await sm_copy.activate_initial_state()
-        assert sm_copy.current_state == AsyncTrafficLightMachine.yellow
+        assert sm_copy.yellow.is_active
         await sm_copy.cycle()
-        assert sm_copy.current_state == AsyncTrafficLightMachine.red
+        assert sm_copy.red.is_active
 
     asyncio.run(setup_and_verify())

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -6,7 +6,7 @@ from statemachine.dispatcher import Listeners
 from statemachine.dispatcher import resolver_factory_from_objects
 from statemachine.exceptions import InvalidDefinition
 from statemachine.state import State
-from statemachine.statemachine import StateMachine
+from statemachine.statemachine import StateChart
 
 
 def _take_first_callable(iterable):
@@ -150,7 +150,9 @@ class TestSearchProperty:
             def can_change_to_start(self):
                 return False
 
-        class StartMachine(StateMachine):
+        class StartMachine(StateChart):
+            error_on_execution = False
+
             created = State(initial=True)
             started = State(final=True)
 

--- a/tests/test_error_execution.py
+++ b/tests/test_error_execution.py
@@ -4,7 +4,6 @@ from statemachine.exceptions import InvalidDefinition
 from statemachine import Event
 from statemachine import State
 from statemachine import StateChart
-from statemachine import StateMachine
 
 
 class ErrorInGuardSC(StateChart):
@@ -54,8 +53,10 @@ class ErrorInAfterSC(StateChart):
         raise RuntimeError("after failed")
 
 
-class ErrorInGuardSM(StateMachine):
-    """StateMachine subclass: exceptions should propagate."""
+class ErrorInGuardSM(StateChart):
+    """StateChart subclass with error_on_execution=False: exceptions should propagate."""
+
+    error_on_execution = False
 
     initial = State("initial", initial=True)
 
@@ -65,10 +66,8 @@ class ErrorInGuardSM(StateMachine):
         raise RuntimeError("guard failed")
 
 
-class ErrorInActionSMWithFlag(StateMachine):
-    """StateMachine subclass with error_on_execution = True."""
-
-    error_on_execution = True
+class ErrorInActionSMWithFlag(StateChart):
+    """StateChart subclass (error_on_execution = True by default)."""
 
     s1 = State("s1", initial=True)
     s2 = State("s2")
@@ -144,7 +143,7 @@ def test_exception_in_after_sends_error_execution_no_rollback():
 
 
 def test_statemachine_exception_propagates():
-    """StateMachine (error_on_execution=False) should propagate exceptions normally."""
+    """StateChart with error_on_execution=False should propagate exceptions normally."""
     sm = ErrorInGuardSM()
     assert sm.configuration == {sm.initial}
 
@@ -184,7 +183,7 @@ def test_error_in_error_handler_no_infinite_loop():
 
 
 def test_statemachine_with_error_on_execution_true():
-    """Custom StateMachine subclass with error_on_execution=True should catch errors."""
+    """StateChart (error_on_execution=True by default) should catch errors."""
     sm = ErrorInActionSMWithFlag()
     assert sm.configuration == {sm.s1}
 
@@ -496,11 +495,9 @@ class TestErrorConventionLOTR:
         assert sm.configuration == {sm.betrayed}
 
     def test_statemachine_with_convention_and_flag(self):
-        """StateMachine with error_on_execution=True uses the error_ convention."""
+        """StateChart (error_on_execution=True by default) uses the error_ convention."""
 
-        class SarumanBetrayal(StateMachine):
-            error_on_execution = True
-
+        class SarumanBetrayal(StateChart):
             white_council = State("white_council", initial=True)
             orthanc = State("orthanc", final=True)
 
@@ -515,9 +512,11 @@ class TestErrorConventionLOTR:
         assert sm.configuration == {sm.orthanc}
 
     def test_statemachine_without_flag_propagates(self):
-        """StateMachine without error_on_execution=True propagates errors even with convention."""
+        """StateChart with error_on_execution=False propagates errors even with convention."""
 
-        class AragornSword(StateMachine):
+        class AragornSword(StateChart):
+            error_on_execution = False
+
             broken = State("broken", initial=True)
 
             reforge = broken.to(broken, on="attempt_reforge")
@@ -955,7 +954,9 @@ class TestEngineErrorPropagation:
     def test_runtime_error_in_after_without_error_on_execution_propagates(self):
         """RuntimeError in after callback without error_on_execution raises."""
 
-        class SM(StateMachine):
+        class SM(StateChart):
+            error_on_execution = False
+
             s1 = State(initial=True)
             s2 = State(final=True)
 
@@ -989,7 +990,9 @@ class TestEngineErrorPropagation:
     def test_runtime_error_in_microstep_without_error_on_execution(self):
         """RuntimeError in microstep without error_on_execution raises."""
 
-        class SM(StateMachine):
+        class SM(StateChart):
+            error_on_execution = False
+
             s1 = State(initial=True)
             s2 = State()
 
@@ -1007,7 +1010,9 @@ class TestEngineErrorPropagation:
 def test_internal_queue_processes_raised_events():
     """Internal events raised during processing are handled."""
 
-    class SM(StateMachine):
+    class SM(StateChart):
+        error_on_execution = False
+
         s1 = State(initial=True)
         s2 = State()
         s3 = State(final=True)
@@ -1027,7 +1032,9 @@ def test_internal_queue_processes_raised_events():
 def test_engine_start_when_already_started():
     """start() is a no-op when state machine is already initialized."""
 
-    class SM(StateMachine):
+    class SM(StateChart):
+        error_on_execution = False
+
         s1 = State(initial=True)
         s2 = State(final=True)
 
@@ -1092,7 +1099,9 @@ def test_invalid_definition_in_internal_event_propagates():
 def test_runtime_error_in_internal_event_propagates_without_error_on_execution():
     """RuntimeError in internal event propagates when error_on_execution is False."""
 
-    class SM(StateMachine):
+    class SM(StateChart):
+        error_on_execution = False
+
         s1 = State(initial=True)
         s2 = State()
         s3 = State()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,11 +3,11 @@ from statemachine.event import Event
 from statemachine.exceptions import InvalidDefinition
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 
 
 def test_assign_events_on_transitions():
-    class TrafficLightMachine(StateMachine):
+    class TrafficLightMachine(StateChart):
         "A traffic light machine"
 
         green = State(initial=True)
@@ -34,7 +34,7 @@ def test_assign_events_on_transitions():
 
 class TestExplicitEvent:
     def test_accept_event_instance(self):
-        class StartMachine(StateMachine):
+        class StartMachine(StateChart):
             created = State(initial=True)
             started = State(final=True)
 
@@ -46,10 +46,10 @@ class TestExplicitEvent:
 
         sm = StartMachine()
         sm.send("start")
-        assert sm.current_state == sm.started
+        assert sm.started.is_active
 
     def test_accept_event_name(self):
-        class StartMachine(StateMachine):
+        class StartMachine(StateChart):
             created = State(initial=True)
             started = State(final=True)
 
@@ -60,7 +60,7 @@ class TestExplicitEvent:
         assert StartMachine.start.name == "Start the machine"
 
     def test_derive_name_from_id(self):
-        class StartMachine(StateMachine):
+        class StartMachine(StateChart):
             created = State(initial=True)
             started = State(final=True)
 
@@ -74,7 +74,7 @@ class TestExplicitEvent:
         assert StartMachine.launch_the_machine == StartMachine.launch_the_machine.id
 
     def test_not_derive_name_from_id_if_not_event_class(self):
-        class StartMachine(StateMachine):
+        class StartMachine(StateChart):
             created = State(initial=True)
             started = State(final=True)
 
@@ -90,7 +90,7 @@ class TestExplicitEvent:
     def test_raise_invalid_definition_if_event_name_cannot_be_derived(self):
         with pytest.raises(InvalidDefinition, match="has no id"):
 
-            class StartMachine(StateMachine):
+            class StartMachine(StateChart):
                 created = State(initial=True)
                 started = State()
 
@@ -99,7 +99,7 @@ class TestExplicitEvent:
                 started.to.itself(event=Event())  # event id not defined
 
     def test_derive_from_id(self):
-        class StartMachine(StateMachine):
+        class StartMachine(StateChart):
             created = State(initial=True)
             started = State()
 
@@ -108,7 +108,7 @@ class TestExplicitEvent:
         assert StartMachine.launch_rocket.name == "Launch rocket"
 
     def test_of_passing_event_as_parameters(self):
-        class TrafficLightMachine(StateMachine):
+        class TrafficLightMachine(StateChart):
             "A traffic light machine"
 
             green = State(initial=True)
@@ -142,7 +142,7 @@ class TestExplicitEvent:
         assert sm.go.name == "Go! Go! Go!"
 
     def test_mixing_event_and_parameters(self):
-        class TrafficLightMachine(StateMachine):
+        class TrafficLightMachine(StateChart):
             "A traffic light machine"
 
             green = State(initial=True)
@@ -174,7 +174,7 @@ class TestExplicitEvent:
         assert sm.go.name == "Go! Go! Go!"
 
     def test_name_derived_from_identifier(self):
-        class TrafficLightMachine(StateMachine):
+        class TrafficLightMachine(StateChart):
             "A traffic light machine"
 
             green = State(initial=True)
@@ -205,7 +205,7 @@ class TestExplicitEvent:
         assert sm.go.name == "go"
 
     def test_multiple_ids_from_the_same_event_will_be_converted_to_multiple_events(self):
-        class TrafficLightMachine(StateMachine):
+        class TrafficLightMachine(StateChart):
             "A traffic light machine"
 
             green = State(initial=True)
@@ -234,7 +234,7 @@ class TestExplicitEvent:
         assert sm.send("cycle") == "Running cycle from red to green"
 
     def test_allow_registering_callbacks_using_decorator(self):
-        class TrafficLightMachine(StateMachine):
+        class TrafficLightMachine(StateChart):
             "A traffic light machine"
 
             green = State(initial=True)
@@ -263,7 +263,7 @@ class TestExplicitEvent:
     def test_raise_registering_callbacks_using_decorator_if_no_transitions(self):
         with pytest.raises(InvalidDefinition, match="event with no transitions"):
 
-            class TrafficLightMachine(StateMachine):
+            class TrafficLightMachine(StateChart):
                 "A traffic light machine"
 
                 green = State(initial=True)
@@ -285,7 +285,7 @@ class TestExplicitEvent:
                     )
 
     def test_allow_using_events_as_commands(self):
-        class StartMachine(StateMachine):
+        class StartMachine(StateChart):
             created = State(initial=True)
             started = State()
 
@@ -299,7 +299,7 @@ class TestExplicitEvent:
         assert sm.started.is_active
 
     def test_event_commands_fail_when_unbound_to_instance(self):
-        class StartMachine(StateMachine):
+        class StartMachine(StateChart):
             created = State(initial=True)
             started = State()
 

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -1,4 +1,3 @@
-import pytest
 from statemachine.state import State
 from statemachine.statemachine import StateMachine
 
@@ -56,30 +55,6 @@ class TestObserver:
 
         captured = capsys.readouterr()
         assert captured.out == EXPECTED_LOG_CREATION
-
-    def test_deprecated_api(self, campaign_machine, capsys):
-        class LogObserver:
-            def __init__(self, name):
-                self.name = name
-
-            def on_transition(self, event, state, target):
-                print(f"{self.name} on: {state.id}--({event})-->{target.id}")
-
-            def on_enter_state(self, target, event):
-                print(f"{self.name} enter: {target.id} from {event}")
-
-        sm = campaign_machine()
-
-        with pytest.warns(
-            DeprecationWarning, match="Method `add_observer` has been renamed to `add_listener`."
-        ):
-            sm.add_observer(LogObserver("Frodo"))
-
-        sm.add_job()
-        sm.produce()
-
-        captured = capsys.readouterr()
-        assert captured.out == EXPECTED_LOG_ADD
 
 
 def test_regression_456():

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -1,5 +1,5 @@
 from statemachine.state import State
-from statemachine.statemachine import StateMachine
+from statemachine.statemachine import StateChart
 
 EXPECTED_LOG_ADD = """Frodo on: draft--(add_job)-->draft
 Frodo enter: draft from add_job
@@ -62,7 +62,7 @@ def test_regression_456():
         def __init__(self):
             pass
 
-    class MyMachine(StateMachine):
+    class MyMachine(StateChart):
         first = State("FIRST", initial=True)
 
         second = State("SECOND")

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -12,7 +12,7 @@ def test_mixin_should_instantiate_a_machine(campaign_machine):
     model = MyMixedModel(state="draft")
     assert isinstance(model.statemachine, campaign_machine)
     assert model.state == "draft"
-    assert model.statemachine.current_state == model.statemachine.draft
+    assert model.statemachine.draft.is_active
 
 
 def test_mixin_should_raise_exception_if_machine_class_does_not_exist():

--- a/tests/test_mock_compatibility.py
+++ b/tests/test_mock_compatibility.py
@@ -1,5 +1,5 @@
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 
 
 def test_minimal(mocker):
@@ -9,7 +9,7 @@ def test_minimal(mocker):
     obs = Observer()
     on_enter_state = mocker.spy(obs, "on_enter_state")
 
-    class Machine(StateMachine):
+    class Machine(StateChart):
         a = State("Init", initial=True)
         b = State("Fin")
 

--- a/tests/test_multiple_destinations.py
+++ b/tests/test_multiple_destinations.py
@@ -1,7 +1,7 @@
 import pytest
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 from statemachine import exceptions
 
 
@@ -49,7 +49,7 @@ def test_transition_should_choose_final_state_on_multiple_possibilities(
 
 
 def test_transition_to_first_that_executes_if_multiple_targets():
-    class ApprovalMachine(StateMachine):
+    class ApprovalMachine(StateChart):
         "A workflow"
 
         requested = State(initial=True)
@@ -68,8 +68,11 @@ def test_do_not_transition_if_multiple_targets_with_guard():
     def never_will_pass(event_data):
         return False
 
-    class ApprovalMachine(StateMachine):
+    class ApprovalMachine(StateChart):
         "A workflow"
+
+        allow_event_without_transition = False
+        error_on_execution = False
 
         requested = State(initial=True)
         accepted = State(final=True)
@@ -96,8 +99,10 @@ def test_do_not_transition_if_multiple_targets_with_guard():
 
 
 def test_check_invalid_reference_to_conditions():
-    class ApprovalMachine(StateMachine):
+    class ApprovalMachine(StateChart):
         "A workflow"
+
+        error_on_execution = False
 
         requested = State(initial=True)
         accepted = State(final=True)
@@ -110,8 +115,11 @@ def test_check_invalid_reference_to_conditions():
 
 
 def test_should_change_to_returned_state_on_multiple_target_with_combined_transitions():
-    class ApprovalMachine(StateMachine):
+    class ApprovalMachine(StateChart):
         "A workflow"
+
+        allow_event_without_transition = False
+        error_on_execution = False
 
         requested = State(initial=True)
         accepted = State()
@@ -174,7 +182,7 @@ def test_transition_on_execute_should_be_called_with_run_syntax(approval_machine
 
 
 def test_multiple_values_returned_with_multiple_targets():
-    class ApprovalMachine(StateMachine):
+    class ApprovalMachine(StateChart):
         "A workflow"
 
         requested = State(initial=True)
@@ -201,7 +209,9 @@ def test_multiple_values_returned_with_multiple_targets():
     ],
 )
 def test_multiple_targets_using_or_starting_from_same_origin(payment_failed, expected_state):
-    class InvoiceStateMachine(StateMachine):
+    class InvoiceStateMachine(StateChart):
+        error_on_execution = False
+
         unpaid = State(initial=True)
         paid = State(final=True)
         failed = State()
@@ -213,7 +223,7 @@ def test_multiple_targets_using_or_starting_from_same_origin(payment_failed, exp
 
     invoice_fsm = InvoiceStateMachine()
     invoice_fsm.pay()
-    assert invoice_fsm.current_state.id == expected_state
+    assert invoice_fsm.current_state_value == expected_state
 
 
 def test_order_control(OrderControl):

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -3,10 +3,13 @@ import weakref
 import pytest
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 
 
-class OrderControl(StateMachine):
+class OrderControl(StateChart):
+    allow_event_without_transition = False
+    error_on_execution = False
+
     waiting_for_payment = State(initial=True)
     processing = State()
     shipping = State()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -25,11 +25,8 @@ def test_should_register_a_state_machine(caplog, django_autodiscover_modules):
         add_job = draft.to(draft) | producing.to(producing)
         produce = draft.to(producing)
 
-    assert "CampaignMachine" in registry._REGISTRY
     assert registry.get_machine_cls("tests.test_registry.CampaignMachine") == CampaignMachine
-
-    with pytest.warns(DeprecationWarning, match="fully qualified names"):
-        assert registry.get_machine_cls("CampaignMachine") == CampaignMachine
+    assert "CampaignMachine" not in registry._REGISTRY
 
 
 def test_load_modules_should_call_autodiscover_modules(django_autodiscover_modules):

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -4,12 +4,12 @@ from unittest import mock
 import pytest
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 
 
 @pytest.fixture()
 def chained_after_sm_class():  # noqa: C901
-    class ChainedSM(StateMachine):
+    class ChainedSM(StateChart):
         a = State(initial=True)
         b = State()
         c = State(final=True)
@@ -45,7 +45,7 @@ def chained_after_sm_class():  # noqa: C901
 
 @pytest.fixture()
 def chained_on_sm_class():  # noqa: C901
-    class ChainedSM(StateMachine):
+    class ChainedSM(StateChart):
         s1 = State(initial=True)
         s2 = State()
         s3 = State()
@@ -174,7 +174,7 @@ class TestAsyncEngineRTC:
         ],
     )
     def test_should_preserve_event_order(self, expected):  # noqa: C901
-        class ChainedSM(StateMachine):
+        class ChainedSM(StateChart):
             s1 = State(initial=True)
             s2 = State()
             s3 = State()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -2,12 +2,12 @@ import pytest
 from statemachine.orderedset import OrderedSet
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 
 
 @pytest.fixture()
 def sm_class():
-    class SM(StateMachine):
+    class SM(StateChart):
         pending = State(initial=True)
         waiting_approval = State()
         approved = State(final=True)

--- a/tests/test_state_callbacks.py
+++ b/tests/test_state_callbacks.py
@@ -11,9 +11,9 @@ def event_mock():
 @pytest.fixture()
 def traffic_light_machine(event_mock):  # noqa: C901
     from statemachine import State
-    from statemachine import StateMachine
+    from statemachine import StateChart
 
-    class TrafficLightMachineStateEvents(StateMachine):
+    class TrafficLightMachineStateEvents(StateChart):
         "A traffic light machine"
 
         green = State(initial=True)

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -1,10 +1,8 @@
-import warnings
-
 import pytest
 from statemachine.orderedset import OrderedSet
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 from statemachine import exceptions
 from tests.models import MyModel
 
@@ -34,13 +32,13 @@ def test_machine_should_be_at_start_state(campaign_machine):
     ]
 
     assert model.state == "draft"
-    assert machine.current_state == machine.draft
+    assert machine.draft.is_active
 
 
 def test_machine_should_only_allow_only_one_initial_state():
     with pytest.raises(exceptions.InvalidDefinition):
 
-        class CampaignMachine(StateMachine):
+        class CampaignMachine(StateChart):
             "A workflow machine"
 
             draft = State(initial=True)
@@ -57,7 +55,7 @@ def test_machine_should_only_allow_only_one_initial_state():
 def test_machine_should_activate_initial_state(mocker):
     spy = mocker.Mock()
 
-    class CampaignMachine(StateMachine):
+    class CampaignMachine(StateChart):
         "A workflow machine"
 
         draft = State(initial=True)
@@ -75,7 +73,7 @@ def test_machine_should_activate_initial_state(mocker):
     sm = CampaignMachine()
 
     spy.assert_called_once_with("draft")
-    assert sm.current_state == sm.draft
+    assert sm.draft.is_active
     assert sm.draft.is_active
 
     spy.reset_mock()
@@ -83,14 +81,14 @@ def test_machine_should_activate_initial_state(mocker):
     assert sm.activate_initial_state() is None
 
     spy.assert_not_called()
-    assert sm.current_state == sm.draft
+    assert sm.draft.is_active
     assert sm.draft.is_active
 
 
 def test_machine_should_not_allow_transitions_from_final_state():
     with pytest.raises(exceptions.InvalidDefinition):
 
-        class CampaignMachine(StateMachine):
+        class CampaignMachine(StateChart):
             "A workflow machine"
 
             draft = State(initial=True)
@@ -107,12 +105,12 @@ def test_should_change_state(campaign_machine):
     machine = campaign_machine(model)
 
     assert model.state == "draft"
-    assert machine.current_state == machine.draft
+    assert machine.draft.is_active
 
     machine.produce()
 
     assert model.state == "producing"
-    assert machine.current_state == machine.producing
+    assert machine.producing.is_active
 
 
 def test_should_run_a_transition_that_keeps_the_state(campaign_machine):
@@ -120,19 +118,19 @@ def test_should_run_a_transition_that_keeps_the_state(campaign_machine):
     machine = campaign_machine(model)
 
     assert model.state == "draft"
-    assert machine.current_state == machine.draft
+    assert machine.draft.is_active
 
     machine.add_job()
     assert model.state == "draft"
-    assert machine.current_state == machine.draft
+    assert machine.draft.is_active
 
     machine.produce()
     assert model.state == "producing"
-    assert machine.current_state == machine.producing
+    assert machine.producing.is_active
 
     machine.add_job()
     assert model.state == "producing"
-    assert machine.current_state == machine.producing
+    assert machine.producing.is_active
 
 
 def test_should_change_state_with_multiple_machine_instances(campaign_machine):
@@ -141,19 +139,19 @@ def test_should_change_state_with_multiple_machine_instances(campaign_machine):
     machine1 = campaign_machine(model1)
     machine2 = campaign_machine(model2)
 
-    assert machine1.current_state == campaign_machine.draft
-    assert machine2.current_state == campaign_machine.draft
+    assert machine1.draft.is_active
+    assert machine2.draft.is_active
 
     p1 = machine1.produce
     p2 = machine2.produce
 
     p2()
-    assert machine1.current_state == campaign_machine.draft
-    assert machine2.current_state == campaign_machine.producing
+    assert machine1.draft.is_active
+    assert machine2.producing.is_active
 
     p1()
-    assert machine1.current_state == campaign_machine.producing
-    assert machine2.current_state == campaign_machine.producing
+    assert machine1.producing.is_active
+    assert machine2.producing.is_active
 
 
 def test_machine_should_list_allowed_events_in_the_current_state(campaign_machine):
@@ -182,11 +180,11 @@ def test_machine_should_run_a_transition_by_his_key(campaign_machine):
 
     machine.send("add_job")
     assert model.state == "draft"
-    assert machine.current_state == machine.draft
+    assert machine.draft.is_active
 
     machine.send("produce")
     assert model.state == "producing"
-    assert machine.current_state == machine.producing
+    assert machine.producing.is_active
 
 
 def test_machine_should_use_and_model_attr_other_than_state(campaign_machine):
@@ -195,12 +193,12 @@ def test_machine_should_use_and_model_attr_other_than_state(campaign_machine):
 
     assert getattr(model, "state", None) is None
     assert model.status == "producing"
-    assert machine.current_state == machine.producing
+    assert machine.producing.is_active
 
     machine.deliver()
 
     assert model.status == "closed"
-    assert machine.current_state == machine.closed
+    assert machine.closed.is_active
 
 
 def test_cant_assign_an_invalid_state_directly(campaign_machine):
@@ -303,14 +301,12 @@ def test_state_machine_with_a_invalid_model_state_value(request, campaign_machin
     model = MyModel(state="tapioca")
     sm = machine_cls(model)
 
-    with pytest.raises(
-        exceptions.InvalidStateValue, match="'tapioca' is not a valid state value."
-    ):
-        assert sm.current_state == sm.draft
+    with pytest.raises(KeyError):
+        sm.configuration  # noqa: B018
 
 
 def test_should_not_create_instance_of_abstract_machine():
-    class EmptyMachine(StateMachine):
+    class EmptyMachine(StateChart):
         "An empty machine"
 
         pass
@@ -322,7 +318,7 @@ def test_should_not_create_instance_of_abstract_machine():
 def test_should_not_create_instance_of_machine_without_states():
     s1 = State()
 
-    class OnlyTransitionMachine(StateMachine):
+    class OnlyTransitionMachine(StateChart):
         t1 = s1.to.itself()
 
     with pytest.raises(exceptions.InvalidDefinition):
@@ -333,7 +329,7 @@ def test_should_not_create_instance_of_machine_without_states():
 def test_should_not_create_instance_of_machine_without_transitions():
     with pytest.raises(exceptions.InvalidDefinition):
 
-        class NoTransitionsMachine(StateMachine):
+        class NoTransitionsMachine(StateChart):
             "A machine without transitions"
 
             initial = State(initial=True)
@@ -346,7 +342,7 @@ def test_should_not_create_disconnected_machine():
     )
     with pytest.raises(exceptions.InvalidDefinition, match=expected):
 
-        class BrokenTrafficLightMachine(StateMachine):
+        class BrokenTrafficLightMachine(StateChart):
             "A broken traffic light machine"
 
             green = State(initial=True)
@@ -363,7 +359,7 @@ def test_should_not_create_big_disconnected_machine():
     )
     with pytest.raises(exceptions.InvalidDefinition, match=expected):
 
-        class BrokenTrafficLightMachine(StateMachine):
+        class BrokenTrafficLightMachine(StateChart):
             "A broken traffic light machine"
 
             green = State(initial=True)
@@ -382,7 +378,7 @@ def test_state_value_is_correct():
     STATE_NEW = 0
     STATE_DRAFT = 1
 
-    class ValueTestModel(StateMachine, strict_states=False):
+    class ValueTestModel(StateChart, strict_states=False):
         new = State(STATE_NEW, value=STATE_NEW, initial=True)
         draft = State(STATE_DRAFT, value=STATE_DRAFT, final=True)
 
@@ -443,7 +439,7 @@ class TestWarnings:
             match=r"have no outgoing transition: \['state_without_outgoing_transition'\]",
         ):
 
-            class TrapStateMachine(StateMachine):
+            class TrapStateMachine(StateChart):
                 initial = State(initial=True)
                 state_without_outgoing_transition = State()
 
@@ -455,7 +451,7 @@ class TestWarnings:
             match=r"have no path to a final state: \['producing'\]",
         ):
 
-            class TrapStateMachine(StateMachine):
+            class TrapStateMachine(StateChart):
                 started = State(initial=True)
                 closed = State(final=True)
                 producing = State()
@@ -483,7 +479,7 @@ def test_model_with_custom_bool_is_not_replaced(campaign_machine):
 def test_abstract_sm_no_states():
     """A state machine class with no states is abstract."""
 
-    class AbstractSM(StateMachine):
+    class AbstractSM(StateChart):
         pass
 
     assert AbstractSM._abstract is True
@@ -492,7 +488,7 @@ def test_abstract_sm_no_states():
 def test_raise_sends_internal_event():
     """raise_ sends an internal event."""
 
-    class SM(StateMachine):
+    class SM(StateChart):
         s1 = State(initial=True)
         s2 = State(final=True)
 
@@ -506,7 +502,7 @@ def test_raise_sends_internal_event():
 def test_configuration_values_returns_ordered_set():
     """configuration_values returns OrderedSet."""
 
-    class SM(StateMachine):
+    class SM(StateChart):
         s1 = State(initial=True)
         s2 = State(final=True)
 
@@ -517,27 +513,10 @@ def test_configuration_values_returns_ordered_set():
     assert isinstance(vals, OrderedSet)
 
 
-def test_current_state_with_list_value():
-    """current_state (deprecated) handles list current_state_value."""
-
-    class SM(StateMachine):
-        s1 = State(initial=True)
-        s2 = State(final=True)
-
-        go = s1.to(s2)
-
-    sm = SM()
-    setattr(sm.model, sm.state_field, [sm.s1.value])
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        config = sm.current_state
-    assert sm.s1 in config
-
-
 def test_states_getitem():
     """States supports index access."""
 
-    class SM(StateMachine):
+    class SM(StateChart):
         s1 = State(initial=True)
         s2 = State(final=True)
 
@@ -551,7 +530,7 @@ def test_multiple_initial_states_raises():
     """Multiple initial states raise InvalidDefinition."""
     with pytest.raises(exceptions.InvalidDefinition, match="one and only one initial state"):
 
-        class BadSM(StateMachine):
+        class BadSM(StateChart):
             s1 = State(initial=True)
             s2 = State(initial=True)
 
@@ -588,7 +567,7 @@ class TestEnabledEvents:
         assert [e.id for e in sm.enabled_events()] == [e.id for e in sm.allowed_events]
 
     def test_passing_condition_returns_event(self):
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State(final=True)
 
@@ -601,7 +580,7 @@ class TestEnabledEvents:
         assert [e.id for e in sm.enabled_events()] == ["go"]
 
     def test_failing_condition_excludes_event(self):
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State(final=True)
 
@@ -616,7 +595,7 @@ class TestEnabledEvents:
     def test_multiple_transitions_one_passes(self):
         """Same event with multiple transitions: included if at least one passes."""
 
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State()
             s2 = State(final=True)
@@ -635,7 +614,7 @@ class TestEnabledEvents:
     def test_duplicate_event_across_transitions_deduplicated(self):
         """Same event on multiple passing transitions appears only once."""
 
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State()
             s2 = State(final=True)
@@ -660,7 +639,7 @@ class TestEnabledEvents:
         assert sm.enabled_events() == []
 
     def test_kwargs_forwarded_to_conditions(self):
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State(final=True)
 
@@ -676,7 +655,7 @@ class TestEnabledEvents:
     def test_condition_exception_treated_as_enabled(self):
         """If a condition raises, the event is treated as enabled (permissive)."""
 
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State(final=True)
 
@@ -689,7 +668,7 @@ class TestEnabledEvents:
         assert [e.id for e in sm.enabled_events()] == ["go"]
 
     def test_mixed_enabled_and_disabled(self):
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State()
             s2 = State(final=True)
@@ -707,7 +686,7 @@ class TestEnabledEvents:
         assert [e.id for e in sm.enabled_events()] == ["go"]
 
     def test_unless_condition(self):
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State(final=True)
 
@@ -720,7 +699,7 @@ class TestEnabledEvents:
         assert sm.enabled_events() == []
 
     def test_unless_condition_passes(self):
-        class MyMachine(StateMachine):
+        class MyMachine(StateChart):
             s0 = State(initial=True)
             s1 = State(final=True)
 

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -156,25 +156,6 @@ def test_should_change_state_with_multiple_machine_instances(campaign_machine):
     assert machine2.current_state == campaign_machine.producing
 
 
-@pytest.mark.parametrize(
-    ("current_state", "transition"),
-    [
-        ("draft", "deliver"),
-        ("closed", "add_job"),
-    ],
-)
-def test_call_to_transition_that_is_not_in_the_current_state_should_raise_exception(
-    campaign_machine, current_state, transition
-):
-    model = MyModel(state=current_state)
-    machine = campaign_machine(model)
-
-    assert machine.current_state.value == current_state
-
-    with pytest.raises(exceptions.TransitionNotAllowed):
-        machine.send(transition)
-
-
 def test_machine_should_list_allowed_events_in_the_current_state(campaign_machine):
     model = MyModel()
     machine = campaign_machine(model)
@@ -206,18 +187,6 @@ def test_machine_should_run_a_transition_by_his_key(campaign_machine):
     machine.send("produce")
     assert model.state == "producing"
     assert machine.current_state == machine.producing
-
-
-def test_machine_should_raise_an_exception_if_a_transition_by_his_key_is_not_found(
-    campaign_machine,
-):
-    model = MyModel()
-    machine = campaign_machine(model)
-
-    assert model.state == "draft"
-
-    with pytest.raises(exceptions.TransitionNotAllowed):
-        machine.send("go_horse")
 
 
 def test_machine_should_use_and_model_attr_other_than_state(campaign_machine):

--- a/tests/test_statemachine_bounded_transitions.py
+++ b/tests/test_statemachine_bounded_transitions.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 
 from .models import MyModel
 
@@ -15,7 +15,7 @@ def event_mock():
 
 @pytest.fixture()
 def state_machine(event_mock):
-    class CampaignMachine(StateMachine):
+    class CampaignMachine(StateChart):
         draft = State(initial=True)
         producing = State()
         closed = State(final=True)

--- a/tests/test_statemachine_compat.py
+++ b/tests/test_statemachine_compat.py
@@ -1,0 +1,374 @@
+"""Backward-compatibility tests for the StateMachine (v2) API.
+
+These tests verify that ``StateMachine`` (which inherits from ``StateChart``
+with different defaults) continues to work as expected.  Tests here exercise
+behaviour that differs from ``StateChart`` defaults:
+
+- ``allow_event_without_transition = False``  → ``TransitionNotAllowed``
+- ``enable_self_transition_entries = False``
+- ``atomic_configuration_update = True``
+- ``error_on_execution = False``  → exceptions propagate directly
+- ``current_state`` deprecated property
+"""
+
+import warnings
+
+import pytest
+
+from statemachine import State
+from statemachine import StateMachine
+from statemachine import exceptions
+
+# ---------------------------------------------------------------------------
+# Flag defaults
+# ---------------------------------------------------------------------------
+
+
+class TestStateMachineDefaults:
+    """Verify the four class-level flag defaults on StateMachine."""
+
+    def test_allow_event_without_transition(self):
+        assert StateMachine.allow_event_without_transition is False
+
+    def test_enable_self_transition_entries(self):
+        assert StateMachine.enable_self_transition_entries is False
+
+    def test_atomic_configuration_update(self):
+        assert StateMachine.atomic_configuration_update is True
+
+    def test_error_on_execution(self):
+        assert StateMachine.error_on_execution is False
+
+
+# ---------------------------------------------------------------------------
+# Smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestStateMachineSmoke:
+    """StateMachine as a subclass works for basic operations."""
+
+    def test_create_send_and_check_state(self):
+        class TrafficLight(StateMachine):
+            green = State(initial=True)
+            yellow = State()
+            red = State()
+
+            cycle = green.to(yellow) | yellow.to(red) | red.to(green)
+
+        sm = TrafficLight()
+        assert sm.green.is_active
+
+        sm.send("cycle")
+        assert sm.yellow.is_active
+
+        sm.send("cycle")
+        assert sm.red.is_active
+
+    def test_final_state_terminates(self):
+        class Simple(StateMachine):
+            s1 = State(initial=True)
+            s2 = State(final=True)
+
+            go = s1.to(s2)
+
+        sm = Simple()
+        sm.send("go")
+        assert sm.is_terminated
+
+
+# ---------------------------------------------------------------------------
+# TransitionNotAllowed (allow_event_without_transition = False)
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionNotAllowed:
+    """StateMachine raises TransitionNotAllowed for invalid events."""
+
+    @pytest.fixture()
+    def sm(self):
+        class Workflow(StateMachine):
+            draft = State(initial=True)
+            published = State(final=True)
+
+            publish = draft.to(published)
+
+        return Workflow()
+
+    def test_invalid_event_raises(self, sm):
+        with pytest.raises(exceptions.TransitionNotAllowed):
+            sm.send("nonexistent")
+
+    def test_event_not_available_in_current_state(self, sm):
+        sm.send("publish")
+        with pytest.raises(exceptions.TransitionNotAllowed):
+            sm.send("publish")
+
+    def test_condition_blocks_transition(self):
+        class Gated(StateMachine):
+            s1 = State(initial=True)
+            s2 = State(final=True)
+
+            go = s1.to(s2, cond="allowed")
+
+            allowed: bool = False
+
+        sm = Gated()
+        with pytest.raises(sm.TransitionNotAllowed):
+            sm.go()
+
+    def test_multiple_destinations_all_blocked(self):
+        def never(event_data):
+            return False
+
+        class Multi(StateMachine):
+            requested = State(initial=True)
+            accepted = State(final=True)
+            rejected = State(final=True)
+
+            validate = requested.to(accepted, cond=never) | requested.to(
+                rejected, cond="also_never"
+            )
+
+            @property
+            def also_never(self):
+                return False
+
+        sm = Multi()
+        with pytest.raises(exceptions.TransitionNotAllowed):
+            sm.validate()
+        assert sm.requested.is_active
+
+    def test_from_any_with_cond_blocked(self):
+        class Account(StateMachine):
+            active = State(initial=True)
+            closed = State(final=True)
+
+            close = closed.from_.any(cond="can_close")
+
+            can_close: bool = False
+
+        sm = Account()
+        with pytest.raises(sm.TransitionNotAllowed):
+            sm.close()
+
+    def test_condition_algebra_any_false(self):
+        class CondAlgebra(StateMachine):
+            start = State(initial=True)
+            end = State(final=True)
+
+            submit = start.to(end, cond="used_money or used_credit")
+
+            used_money: bool = False
+            used_credit: bool = False
+
+        sm = CondAlgebra()
+        with pytest.raises(sm.TransitionNotAllowed):
+            sm.submit()
+
+
+# ---------------------------------------------------------------------------
+# TransitionNotAllowed — async
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionNotAllowedAsync:
+    """TransitionNotAllowed in async machines."""
+
+    @pytest.fixture()
+    def async_sm_cls(self):
+        class AsyncWorkflow(StateMachine):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State(final=True)
+
+            go = s1.to(s2, cond="is_ready")
+            finish = s2.to(s3)
+
+            is_ready: bool = False
+
+            async def on_go(self): ...
+
+        return AsyncWorkflow
+
+    async def test_async_transition_not_allowed(self, async_sm_cls):
+        sm = async_sm_cls()
+        await sm.activate_initial_state()
+        with pytest.raises(sm.TransitionNotAllowed):
+            await sm.send("go")
+
+    def test_sync_context_transition_not_allowed(self, async_sm_cls):
+        sm = async_sm_cls()
+        with pytest.raises(sm.TransitionNotAllowed):
+            sm.send("go")
+
+    async def test_async_condition_blocks(self):
+        class AsyncCond(StateMachine):
+            s1 = State(initial=True)
+            s2 = State(final=True)
+
+            go = s1.to(s2, cond="check")
+
+            async def check(self):
+                return False
+
+        sm = AsyncCond()
+        await sm.activate_initial_state()
+        with pytest.raises(sm.TransitionNotAllowed):
+            await sm.go()
+
+
+# ---------------------------------------------------------------------------
+# error_on_execution = False (exceptions propagate directly)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorOnExecutionFalse:
+    """With error_on_execution=False, exceptions propagate without being caught."""
+
+    def test_runtime_error_in_action_propagates(self):
+        class SM(StateMachine):
+            s1 = State(initial=True)
+            s2 = State(final=True)
+
+            go = s1.to(s2)
+
+            def on_go(self):
+                raise RuntimeError("boom")
+
+        sm = SM()
+        with pytest.raises(RuntimeError, match="boom"):
+            sm.send("go")
+
+    def test_runtime_error_in_after_propagates(self):
+        class SM(StateMachine):
+            s1 = State(initial=True)
+            s2 = State(final=True)
+
+            go = s1.to(s2)
+
+            def after_go(self):
+                raise RuntimeError("after boom")
+
+        sm = SM()
+        with pytest.raises(RuntimeError, match="after boom"):
+            sm.send("go")
+
+    @pytest.mark.timeout(5)
+    async def test_async_runtime_error_in_after_propagates(self):
+        class SM(StateMachine):
+            s1 = State(initial=True)
+            s2 = State(final=True)
+
+            go = s1.to(s2)
+
+            async def after_go(self, **kwargs):
+                raise RuntimeError("async after boom")
+
+        sm = SM()
+        await sm.activate_initial_state()
+        with pytest.raises(RuntimeError, match="async after boom"):
+            await sm.send("go")
+
+
+# ---------------------------------------------------------------------------
+# enable_self_transition_entries = False
+# ---------------------------------------------------------------------------
+
+
+class TestSelfTransitionNoEntries:
+    """With enable_self_transition_entries=False, internal self-transitions do NOT fire entry/exit.
+
+    Note: ``enable_self_transition_entries`` only applies to *internal* self-transitions
+    (``internal=True``). External self-transitions always fire entry/exit regardless.
+    """
+
+    def test_internal_self_transition_does_not_fire_enter_exit(self):
+        log = []
+
+        class SM(StateMachine):
+            s1 = State(initial=True)
+
+            loop = s1.to.itself(internal=True)
+
+            def on_enter_s1(self):
+                log.append("enter_s1")
+
+            def on_exit_s1(self):
+                log.append("exit_s1")
+
+        sm = SM()
+        log.clear()  # clear initial enter
+        sm.send("loop")
+        assert "enter_s1" not in log
+        assert "exit_s1" not in log
+
+    def test_external_self_transition_fires_enter_exit(self):
+        """External self-transitions always fire, regardless of the flag."""
+        log = []
+
+        class SM(StateMachine):
+            s1 = State(initial=True)
+
+            loop = s1.to.itself()
+
+            def on_enter_s1(self):
+                log.append("enter_s1")
+
+            def on_exit_s1(self):
+                log.append("exit_s1")
+
+        sm = SM()
+        log.clear()
+        sm.send("loop")
+        assert "enter_s1" in log
+        assert "exit_s1" in log
+
+
+# ---------------------------------------------------------------------------
+# current_state deprecated property
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentStateDeprecated:
+    """The current_state property emits DeprecationWarning but still works."""
+
+    def test_current_state_returns_state(self):
+        class SM(StateMachine):
+            s1 = State(initial=True)
+            s2 = State(final=True)
+
+            go = s1.to(s2)
+
+        sm = SM()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cs = sm.current_state
+        assert cs == sm.s1
+
+    def test_current_state_emits_warning(self):
+        class SM(StateMachine):
+            s1 = State(initial=True)
+            s2 = State(final=True)
+
+            go = s1.to(s2)
+
+        sm = SM()
+        with pytest.warns(DeprecationWarning, match="current_state"):
+            _ = sm.current_state  # noqa: F841
+
+    def test_current_state_with_list_value(self):
+        """current_state handles list current_state_value (backward compat)."""
+
+        class SM(StateMachine):
+            s1 = State(initial=True)
+            s2 = State(final=True)
+
+            go = s1.to(s2)
+
+        sm = SM()
+        setattr(sm.model, sm.state_field, [sm.s1.value])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            config = sm.current_state
+        assert sm.s1 in config

--- a/tests/test_statemachine_inheritance.py
+++ b/tests/test_statemachine_inheritance.py
@@ -6,9 +6,9 @@ from statemachine import exceptions
 @pytest.fixture()
 def BaseMachine():
     from statemachine import State
-    from statemachine import StateMachine
+    from statemachine import StateChart
 
-    class BaseMachine(StateMachine, strict_states=False):
+    class BaseMachine(StateChart, strict_states=False):
         state_1 = State(initial=True)
         state_2 = State()
         trans_1_2 = state_1.to(state_2)

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -2,7 +2,7 @@ import threading
 import time
 
 from statemachine.state import State
-from statemachine.statemachine import StateMachine
+from statemachine.statemachine import StateChart
 
 
 def test_machine_should_allow_multi_thread_event_changes():
@@ -10,7 +10,7 @@ def test_machine_should_allow_multi_thread_event_changes():
     Test for https://github.com/fgmacedo/python-statemachine/issues/443
     """
 
-    class CampaignMachine(StateMachine):
+    class CampaignMachine(StateChart):
         "A workflow machine"
 
         draft = State(initial=True)
@@ -27,7 +27,7 @@ def test_machine_should_allow_multi_thread_event_changes():
     thread = threading.Thread(target=off_thread_change_state)
     thread.start()
     thread.join()
-    assert machine.current_state.id == "producing"
+    assert machine.current_state_value == "producing"
 
 
 def test_regression_443():
@@ -38,7 +38,7 @@ def test_regression_443():
     time_to_send = 0.125
     time_sampling_current_state = 0.05
 
-    class TrafficLightMachine(StateMachine):
+    class TrafficLightMachine(StateChart):
         "A traffic light machine"
 
         green = State(initial=True)
@@ -65,7 +65,7 @@ def test_regression_443():
                     sent = True
 
                 waiting_time += time_sampling_current_state
-                self.statuses_history.append(self.fsm.current_state.id)
+                self.statuses_history.append(self.fsm.current_state_value)
                 time.sleep(time_sampling_current_state)
 
     c1 = Controller()
@@ -83,7 +83,7 @@ def test_regression_443_with_modifications():
     time_to_send = 0.125
     time_sampling_current_state = 0.05
 
-    class TrafficLightMachine(StateMachine):
+    class TrafficLightMachine(StateChart):
         "A traffic light machine"
 
         green = State(initial=True)
@@ -105,7 +105,7 @@ def test_regression_443_with_modifications():
                     self.cycle()
                     sent = True
 
-                self.statuses_history.append(f"{self.name}.{self.current_state.id}")
+                self.statuses_history.append(f"{self.name}.{self.current_state_value}")
 
                 time.sleep(time_sampling_current_state)
                 waiting_time += time_sampling_current_state
@@ -135,7 +135,7 @@ async def test_regression_443_with_modifications_for_async_engine():  # noqa: C9
     time_to_send = 0.125
     time_sampling_current_state = 0.05
 
-    class TrafficLightMachine(StateMachine):
+    class TrafficLightMachine(StateChart):
         "A traffic light machine"
 
         green = State(initial=True)
@@ -160,7 +160,7 @@ async def test_regression_443_with_modifications_for_async_engine():  # noqa: C9
                     self.cycle()
                     sent = True
 
-                self.statuses_history.append(f"{self.name}.{self.current_state.id}")
+                self.statuses_history.append(f"{self.name}.{self.current_state_value}")
 
                 time.sleep(time_sampling_current_state)
                 waiting_time += time_sampling_current_state

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -3,7 +3,7 @@ from statemachine.exceptions import InvalidDefinition
 from statemachine.transition import Transition
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 
 from .models import MyModel
 
@@ -30,16 +30,16 @@ def test_list_state_transitions(classic_traffic_light_machine):
 
 def test_transition_should_accept_decorator_syntax(traffic_light_machine):
     machine = traffic_light_machine()
-    assert machine.current_state == machine.green
+    assert machine.green.is_active
 
 
 def test_transition_as_decorator_should_call_method_before_activating_state(
     traffic_light_machine, capsys
 ):
     machine = traffic_light_machine()
-    assert machine.current_state == machine.green
+    assert machine.green.is_active
     machine.cycle(1, 2, number=3, text="x")
-    assert machine.current_state == machine.yellow
+    assert machine.yellow.is_active
 
     captured = capsys.readouterr()
     assert captured.out == "Running cycle from green to yellow\n"
@@ -57,7 +57,7 @@ def test_cycle_transitions(request, machine_name):
     machine = machine_class()
     expected_states = ["green", "yellow", "red"] * 2
     for expected_state in expected_states:
-        assert machine.current_state.id == expected_state
+        assert machine.current_state_value == expected_state
         machine.cycle()
 
 
@@ -87,7 +87,7 @@ def test_transition_list_call_can_only_be_used_as_decorator():
 def transition_callback_machine(request):
     if request.param == "bounded":
 
-        class ApprovalMachine(StateMachine):
+        class ApprovalMachine(StateChart):
             "A workflow"
 
             requested = State(initial=True)
@@ -101,7 +101,7 @@ def transition_callback_machine(request):
 
     elif request.param == "unbounded":
 
-        class ApprovalMachine(StateMachine):
+        class ApprovalMachine(StateChart):
             "A workflow"
 
             requested = State(initial=True)
@@ -126,7 +126,7 @@ def test_statemachine_transition_callback(transition_callback_machine):
 
 
 def test_can_run_combined_transitions():
-    class CampaignMachine(StateMachine):
+    class CampaignMachine(StateChart):
         "A workflow machine"
 
         draft = State(initial=True)
@@ -149,7 +149,7 @@ def test_can_detect_stuck_states():
         match="All non-final states should have at least one outgoing transition.",
     ):
 
-        class CampaignMachine(StateMachine, strict_states=True):
+        class CampaignMachine(StateChart, strict_states=True):
             "A workflow machine"
 
             draft = State(initial=True)
@@ -168,7 +168,7 @@ def test_can_detect_unreachable_final_states():
         match="All non-final states should have at least one path to a final state.",
     ):
 
-        class CampaignMachine(StateMachine, strict_states=True):
+        class CampaignMachine(StateChart, strict_states=True):
             "A workflow machine"
 
             draft = State(initial=True)
@@ -182,7 +182,7 @@ def test_can_detect_unreachable_final_states():
 
 
 def test_transitions_to_the_same_estate_as_itself():
-    class CampaignMachine(StateMachine):
+    class CampaignMachine(StateChart):
         "A workflow machine"
 
         draft = State(initial=True)
@@ -211,7 +211,7 @@ class TestReverseTransition:
     )
     def test_reverse_transition(self, reverse_traffic_light_machine, initial_state):
         machine = reverse_traffic_light_machine(start_value=initial_state)
-        assert machine.current_state.id == initial_state
+        assert machine.current_state_value == initial_state
 
         machine.stop()
 
@@ -227,7 +227,7 @@ def test_should_transition_with_a_dict_as_return():
         "c": 3,
     }
 
-    class ApprovalMachine(StateMachine):
+    class ApprovalMachine(StateChart):
         "A workflow"
 
         requested = State(initial=True)
@@ -247,22 +247,13 @@ def test_should_transition_with_a_dict_as_return():
 
 
 class TestInternalTransition:
-    @pytest.mark.parametrize(
-        ("internal", "expected_calls"),
-        [
-            (False, ["on_exit_initial", "on_enter_initial"]),
-            (True, []),
-        ],
-    )
-    def test_should_not_execute_state_actions_on_internal_transitions(
-        self, internal, expected_calls, engine
-    ):
+    def test_external_self_transition_executes_state_actions(self, engine):
         calls = []
 
-        class TestStateMachine(StateMachine):
+        class TestStateMachine(StateChart):
             initial = State(initial=True)
 
-            loop = initial.to.itself(internal=internal)
+            loop = initial.to.itself(internal=False)
 
             def _get_engine(self):
                 return engine(self)
@@ -278,14 +269,40 @@ class TestInternalTransition:
 
         calls.clear()
         sm.loop()
-        assert calls == expected_calls
+        assert calls == ["on_exit_initial", "on_enter_initial"]
+
+    def test_internal_self_transition_skips_state_actions(self, engine):
+        calls = []
+
+        class TestStateMachine(StateChart):
+            enable_self_transition_entries = False
+
+            initial = State(initial=True)
+
+            loop = initial.to.itself(internal=True)
+
+            def _get_engine(self):
+                return engine(self)
+
+            def on_exit_initial(self):
+                calls.append("on_exit_initial")
+
+            def on_enter_initial(self):
+                calls.append("on_enter_initial")
+
+        sm = TestStateMachine()
+        sm.activate_initial_state()
+
+        calls.clear()
+        sm.loop()
+        assert calls == []
 
     def test_should_not_allow_internal_transitions_from_distinct_states(self):
         with pytest.raises(
             InvalidDefinition, match="Not a valid internal transition from source."
         ):
 
-            class TestStateMachine(StateMachine):
+            class TestStateMachine(StateChart):
                 initial = State(initial=True)
                 final = State(final=True)
 
@@ -315,7 +332,10 @@ class TestAllowEventWithoutTransition:
 class TestTransitionFromAny:
     @pytest.fixture()
     def account_sm(self):
-        class AccountStateMachine(StateMachine):
+        class AccountStateMachine(StateChart):
+            allow_event_without_transition = False
+            error_on_execution = False
+
             active = State("Active", initial=True)
             suspended = State("Suspended")
             overdrawn = State("Overdrawn")
@@ -361,7 +381,9 @@ class TestTransitionFromAny:
         assert sm.active.is_active
 
     def test_any_can_be_used_as_decorator(self):
-        class AccountStateMachine(StateMachine):
+        class AccountStateMachine(StateChart):
+            error_on_execution = False
+
             active = State("Active", initial=True)
             suspended = State("Suspended")
             overdrawn = State("Overdrawn")

--- a/tests/testcases/issue308.md
+++ b/tests/testcases/issue308.md
@@ -6,9 +6,9 @@ A StateMachine that exercises the example given on issue
 In this example, we share the transition list between events.
 
 ```py
->>> from statemachine import StateMachine, State
+>>> from statemachine import StateChart, State
 
->>> class TestSM(StateMachine):
+>>> class TestSM(StateChart):
 ...     state1 = State('s1', initial=True)
 ...     state2 = State('s2')
 ...     state3 = State('s3')
@@ -91,31 +91,37 @@ Example given:
 >>> m = TestSM()
 enter state1
 
->>> m.state1.is_active, m.state2.is_active, m.state3.is_active, m.state4.is_active, m.current_state ; _ = m.cycle()
-(True, False, False, False, State('s1', id='state1', value='state1', initial=True, final=False, parallel=False))
+>>> m.state1.is_active, m.state2.is_active, m.state3.is_active, m.state4.is_active, list(m.configuration_values)
+(True, False, False, False, ['state1'])
+
+>>> _ = m.cycle()
 before cycle
 exit state1
 on cycle
 enter state2
 after cycle
 
->>> m.state1.is_active, m.state2.is_active, m.state3.is_active, m.state4.is_active, m.current_state ; _ = m.cycle()
-(False, True, False, False, State('s2', id='state2', value='state2', initial=False, final=False, parallel=False))
+>>> m.state1.is_active, m.state2.is_active, m.state3.is_active, m.state4.is_active, list(m.configuration_values)
+(False, True, False, False, ['state2'])
+
+>>> _ = m.cycle()
 before cycle
 exit state2
 on cycle
 enter state3
 after cycle
 
->>> m.state1.is_active, m.state2.is_active, m.state3.is_active, m.state4.is_active, m.current_state ; _ = m.cycle()
-(False, False, True, False, State('s3', id='state3', value='state3', initial=False, final=False, parallel=False))
+>>> m.state1.is_active, m.state2.is_active, m.state3.is_active, m.state4.is_active, list(m.configuration_values)
+(False, False, True, False, ['state3'])
+
+>>> _ = m.cycle()
 before cycle
 exit state3
 on cycle
 enter state4
 after cycle
 
->>> m.state1.is_active, m.state2.is_active, m.state3.is_active, m.state4.is_active, m.current_state
-(False, False, False, True, State('s4', id='state4', value='state4', initial=False, final=True, parallel=False))
+>>> m.state1.is_active, m.state2.is_active, m.state3.is_active, m.state4.is_active, list(m.configuration_values)
+(False, False, False, True, ['state4'])
 
 ```

--- a/tests/testcases/issue384_multiple_observers.md
+++ b/tests/testcases/issue384_multiple_observers.md
@@ -9,7 +9,7 @@ This works also as a regression test.
 
 ```py
 >>> from statemachine import State
->>> from statemachine import StateMachine
+>>> from statemachine import StateChart
 
 >>> class MyObs:
 ...     def on_move_car(self):
@@ -21,7 +21,7 @@ This works also as a regression test.
 ...
 
 
->>> class Car(StateMachine):
+>>> class Car(StateChart):
 ...     stopped = State(initial=True)
 ...     moving = State()
 ...

--- a/tests/testcases/issue449.md
+++ b/tests/testcases/issue449.md
@@ -7,9 +7,9 @@ A StateMachine that exercises the example given on issue
 
 
 ```py
->>> from statemachine import StateMachine, State
+>>> from statemachine import StateChart, State
 
->>> class ExampleStateMachine(StateMachine):
+>>> class ExampleStateMachine(StateChart):
 ...     initial = State(initial=True)
 ...     second = State()
 ...     third = State()
@@ -40,8 +40,8 @@ Exercise:
 >>> example = ExampleStateMachine()
 Entering state initial. Event: __initial__
 
->>> print(example.current_state)
-Initial
+>>> print(list(example.configuration_values))
+['initial']
 
 >>> example.send("initial_to_second") # this will call second_to_third and third_to_fourth
 Entering state second. Event: initial_to_second
@@ -49,7 +49,7 @@ Entering state third. Event: second_to_third
 Entering state fourth. Event: third_to_fourth
 third_to_fourth on on_enter_state worked
 
->>> print("My current state is", example.current_state)
-My current state is Fourth
+>>> print("My current state is", list(example.configuration_values))
+My current state is ['fourth']
 
 ```

--- a/tests/testcases/test_issue434.py
+++ b/tests/testcases/test_issue434.py
@@ -3,7 +3,7 @@ from time import sleep
 import pytest
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 
 
 class Model:
@@ -11,7 +11,9 @@ class Model:
         self.data = data
 
 
-class DataCheckerMachine(StateMachine):
+class DataCheckerMachine(StateChart):
+    error_on_execution = False
+
     check_data = State(initial=True)
     data_good = State(final=True)
     data_bad = State(final=True)
@@ -50,11 +52,11 @@ def test_max_cycle_without_success(data_checker_machine):
     sm = data_checker_machine
     cycle_rate = 0.1
 
-    while not sm.current_state.final:
+    while not sm.is_terminated:
         sm.cycle()
         sleep(cycle_rate)
 
-    assert sm.current_state == sm.data_bad
+    assert sm.data_bad.is_active
     assert sm.cycle_count == 12
 
 
@@ -62,12 +64,12 @@ def test_data_turns_good_mid_cycle(initial_data):
     sm = DataCheckerMachine(Model(initial_data))
     cycle_rate = 0.1
 
-    while not sm.current_state.final:
+    while not sm.is_terminated:
         sm.cycle()
         if sm.cycle_count == 5:
             print("Now data looks good!")
             sm.model.data["value"] = 20
         sleep(cycle_rate)
 
-    assert sm.current_state == sm.data_good
+    assert sm.data_good.is_active
     assert sm.cycle_count == 6  # Transition occurs at the 6th cycle

--- a/tests/testcases/test_issue480.py
+++ b/tests/testcases/test_issue480.py
@@ -12,10 +12,10 @@ from unittest.mock import MagicMock
 from unittest.mock import call
 
 from statemachine import State
-from statemachine import StateMachine
+from statemachine import StateChart
 
 
-class MyStateMachine(StateMachine):
+class MyStateMachine(StateChart):
     state_1 = State(initial=True)
     state_2 = State(final=True)
 
@@ -53,4 +53,4 @@ def test_initial_state_activation_handler():
     ]
 
     assert sm.mock.mock_calls == expected_calls
-    assert sm.current_state == sm.state_2
+    assert sm.state_2.is_active


### PR DESCRIPTION
## Summary

- **Remove deprecated v2.x APIs**: `add_observer()` (deprecated v2.3.2) and short registry name lookup (deprecated v0.8) are removed
- **Change `States.from_enum` default**: `use_enum_instance` now defaults to `True` (promised in v2.3.3)
- **Migrate entire test suite to `StateChart`**: all test files now use `StateChart` as the base class, with explicit flag overrides where needed (`allow_event_without_transition=False`, `error_on_execution=False`)
- **Add dedicated backward-compat tests**: new `test_statemachine_compat.py` with 23 tests covering `StateMachine` (v2 API) defaults, `TransitionNotAllowed`, `error_on_execution=False`, self-transition entries, and `current_state` deprecation
- **Update source doctests**: `States` class docstring now uses `StateChart`
- **Update release notes and upgrade guide**: document all breaking changes with migration instructions

### Breaking changes

| Change | Since | Action |
|--------|-------|--------|
| `add_observer()` removed | v2.3.2 | Use `add_listener()` |
| Short registry names removed | v0.8 | Use fully-qualified names |
| `use_enum_instance` default `True` | v2.3.3 | Pass `False` explicitly if needed |

### Verification

- 1011 tests passed, 1 skipped, 96 xfailed
- `ruff check .` — all passed
- `ruff format --check .` — all 123 files formatted
- `mypy statemachine/` — 35 files, 0 issues
- `StateMachine` only used in `test_statemachine_compat.py` and `test_registry.py` (intentional)
- `current_state` only used in compat test and async init edge case (intentional)