### PR TITLE
feat: add pyright support, Generic[TModel], remove __getattr__ catch-all

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
     types: [python]
     language: system
     pass_filenames: false
+  - id: pyright
+    name: Pyright
+    entry: uv run pyright statemachine/
+    types: [python]
+    language: system
+    pass_filenames: false
   - id: pytest
     name: Pytest
     entry: uv run pytest -n auto

--- a/docs/models.md
+++ b/docs/models.md
@@ -25,3 +25,45 @@ provided to the built-in {ref}`StateChart`, such as implementing all {ref}`actio
 {ref}`guards` on your domain model and keeping only the definition of {ref}`states` and
 {ref}`transitions` on the {ref}`StateChart`.
 ```
+
+## Typed models
+
+`StateChart` supports a generic type parameter so that type checkers (mypy, pyright) and IDEs
+can infer the type of `sm.model` and provide code completion.
+
+Declare your model class and pass it as a type parameter to `StateChart`:
+
+```python
+>>> from statemachine import State, StateChart
+
+>>> class OrderModel:
+...     order_id: str = ""
+...     total: float = 0.0
+...     def confirm(self):
+...         return f"Order {self.order_id} confirmed: ${self.total}"
+
+>>> class OrderWorkflow(StateChart["OrderModel"]):
+...     draft = State(initial=True)
+...     confirmed = State(final=True)
+...     confirm = draft.to(confirmed, on="on_confirm")
+...     def on_confirm(self):
+...         return self.model.confirm()
+
+>>> model = OrderModel()
+>>> model.order_id = "A-123"
+>>> model.total = 49.90
+>>> sm = OrderWorkflow(model=model)
+
+>>> sm.send("confirm")
+'Order A-123 confirmed: $49.9'
+
+```
+
+With this declaration, `sm.model` is typed as `OrderModel` instead of `Any`, so
+`sm.model.order_id`, `sm.model.total`, and `sm.model.confirm()` all get full
+autocompletion and type checking in your IDE.
+
+```{note}
+When no type parameter is given (e.g. `class MySM(StateChart)`), the model defaults
+to `Any`, preserving full backward compatibility.
+```

--- a/docs/releases/3.0.0.md
+++ b/docs/releases/3.0.0.md
@@ -346,6 +346,41 @@ flag `validate_disconnected_states: bool = True` that can be used to disable thi
 It's already disabled when parsing SCXML files.
 
 
+### Typed models with `Generic[TModel]`
+
+`StateChart` now supports a generic type parameter for the model, enabling full type
+inference and IDE autocompletion on `sm.model`:
+
+```py
+>>> from statemachine import State, StateChart
+
+>>> class MyModel:
+...     name: str = ""
+...     value: int = 0
+
+>>> class MySM(StateChart["MyModel"]):
+...     idle = State(initial=True)
+...     active = State(final=True)
+...     go = idle.to(active)
+
+>>> sm = MySM(model=MyModel())
+>>> sm.model.name
+''
+
+```
+
+With this declaration, type checkers infer `sm.model` as `MyModel` (not `Any`), so
+accessing `sm.model.name` or `sm.model.value` gets full autocompletion and type safety.
+When no type parameter is given, `StateChart` defaults to `StateChart[Any]` for backward
+compatibility. See {ref}`domain models` for details.
+
+### Improved type checking with pyright
+
+The library now supports [pyright](https://github.com/microsoft/pyright) in addition to mypy.
+Type annotations have been improved throughout the codebase, and a catch-all `__getattr__`
+that previously returned `Any` has been removed — type checkers can now detect misspelled
+attribute names and unresolved references on `StateChart` subclasses.
+
 ### Weighted (probabilistic) transitions
 
 A new contrib module `statemachine.contrib.weighted` provides `weighted_transitions()`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "babel >=2.16.0; python_version >='3.8'",
     "pytest-xdist>=3.6.1",
     "pytest-timeout>=2.3.1",
+    "pyright>=1.1.400",
 ]
 
 [build-system]
@@ -201,3 +202,6 @@ fixture-parentheses = true
 mark-parentheses = true
 
 [tool.pyright]
+pythonVersion = "3.9"
+typeCheckingMode = "basic"
+include = ["statemachine"]

--- a/statemachine/__init__.py
+++ b/statemachine/__init__.py
@@ -3,9 +3,10 @@ from .state import HistoryState
 from .state import State
 from .statemachine import StateChart
 from .statemachine import StateMachine
+from .statemachine import TModel
 
 __author__ = """Fernando Macedo"""
 __email__ = "fgmacedo@gmail.com"
 __version__ = "2.6.0"
 
-__all__ = ["StateChart", "StateMachine", "State", "HistoryState", "Event"]
+__all__ = ["StateChart", "StateMachine", "State", "HistoryState", "Event", "TModel"]

--- a/statemachine/callbacks.py
+++ b/statemachine/callbacks.py
@@ -96,8 +96,8 @@ class CallbackSpec:
             name = func.func.__name__ if is_partial else func.__name__
             self.attr_name = name if not self.is_event or self.is_bounded else f"_{name}_"
             if not self.is_bounded:
-                func.attr_name = self.attr_name
-                func.is_event = is_event
+                func.attr_name = self.attr_name  # type: ignore[union-attr]
+                func.is_event = is_event  # type: ignore[union-attr]
         else:
             self.reference = SpecReference.NAME
             self.attr_name = func
@@ -270,7 +270,7 @@ class CallbacksExecutor:
     """A list of callbacks that can be executed in order."""
 
     def __init__(self):
-        self.items: List[CallbackWrapper] = deque()
+        self.items: "deque[CallbackWrapper]" = deque()
         self.items_already_seen = set()
 
     def __iter__(self):

--- a/statemachine/contrib/diagram.py
+++ b/statemachine/contrib/diagram.py
@@ -69,7 +69,7 @@ class DotGraphMachine:
             width=0.2,
             height=0.2,
         )
-        node.set_fillcolor("black")
+        node.set_fillcolor("black")  # type: ignore[attr-defined]
         return node
 
     def _initial_edge(self, initial_node, state):
@@ -89,7 +89,7 @@ class DotGraphMachine:
     def _actions_getter(self):
         if isinstance(self.machine, StateChart):
 
-            def getter(grouper):
+            def getter(grouper):  # pyright: ignore[reportRedeclaration]
                 return self.machine._callbacks.str(grouper.key)
         else:
 
@@ -162,10 +162,10 @@ class DotGraphMachine:
             isinstance(self.machine, StateChart)
             and state.value in self.machine.configuration_values
         ):
-            node.set_penwidth(self.state_active_penwidth)
-            node.set_fillcolor(self.state_active_fillcolor)
+            node.set_penwidth(self.state_active_penwidth)  # type: ignore[attr-defined]
+            node.set_fillcolor(self.state_active_fillcolor)  # type: ignore[attr-defined]
         else:
-            node.set_fillcolor("white")
+            node.set_fillcolor("white")  # type: ignore[attr-defined]
         return node
 
     def _transition_as_edges(self, transition):

--- a/statemachine/dispatcher.py
+++ b/statemachine/dispatcher.py
@@ -194,7 +194,7 @@ def callable_method(a_callable) -> Callable:
 
     if sig.is_coroutine:
 
-        async def signature_adapter(*args: Any, **kwargs: Any) -> Any:
+        async def signature_adapter(*args: Any, **kwargs: Any) -> Any:  # pyright: ignore[reportRedeclaration]
             ba = sig_bind_expected(*args, **kwargs)
             return await a_callable(*ba.args, **ba.kwargs)
     else:

--- a/statemachine/event.py
+++ b/statemachine/event.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import List
 from typing import cast
 from uuid import uuid4
@@ -11,6 +12,7 @@ from .transition_mixin import AddCallbacksMixin
 
 if TYPE_CHECKING:
     from .statemachine import StateChart
+    from .transition import Transition
     from .transition_list import TransitionList
 
 
@@ -57,7 +59,7 @@ class Event(AddCallbacksMixin, str):
 
     def __new__(
         cls,
-        transitions: "str | TransitionList | None" = None,
+        transitions: "str | Transition | TransitionList | None" = None,
         id: "str | None" = None,
         name: "str | None" = None,
         delay: float = 0,
@@ -82,7 +84,7 @@ class Event(AddCallbacksMixin, str):
         else:
             instance.name = ""
         if transitions:
-            instance._transitions = transitions
+            instance._transitions = transitions  # type: ignore[assignment]
         instance._has_real_id = _has_real_id
         instance._sm = _sm
         return instance
@@ -144,7 +146,7 @@ class Event(AddCallbacksMixin, str):
 
         return trigger_data
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs) -> Any:
         """Send this event to the current state machine.
 
         Triggering an event on a state machine means invoking or sending a signal, initiating the
@@ -155,7 +157,7 @@ class Event(AddCallbacksMixin, str):
         # an SM instance. Such SM instance is provided by `__get__` method when
         # used as a property descriptor.
         self.put(*args, **kwargs)
-        return self._sm._processing_loop()  # type: ignore
+        return self._sm._processing_loop()  # type: ignore[union-attr]
 
     def split(  # type: ignore[override]
         self, sep: "str | None" = None, maxsplit: int = -1

--- a/statemachine/events.py
+++ b/statemachine/events.py
@@ -35,8 +35,8 @@ class Events:
         return self
 
     def match(self, event: "str | None"):
-        if event is None and self.is_empty:
-            return True
+        if event is None:
+            return self.is_empty
         return any(e.match(event) for e in self)
 
     def _replace(self, old, new):

--- a/statemachine/factory.py
+++ b/statemachine/factory.py
@@ -1,8 +1,8 @@
 import warnings
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 from . import registry
@@ -49,7 +49,7 @@ class StateMachineMetaclass(type):
         cls._strict_states = strict_states
         cls._events: Dict[Event, None] = {}  # used Dict to preserve order and avoid duplicates
         cls._protected_attrs: set = set()
-        cls._events_to_update: Dict[Event, Event | None] = {}
+        cls._events_to_update: Dict[Event, Optional[Event]] = {}
         cls._specs = CallbackSpecList()
         cls.prepare = cls._specs.grouper(CallbackGroup.PREPARE).add(
             "prepare_event", priority=CallbackPriority.GENERIC, is_convention=True
@@ -85,11 +85,6 @@ class StateMachineMetaclass(type):
 
         cls._check()
         cls._setup()
-
-    if TYPE_CHECKING:
-        """Makes mypy happy with dynamic created attributes"""
-
-        def __getattr__(self, attribute: str) -> Any: ...
 
     def _initials_by_document_order(  # noqa: C901
         cls, states: List[State], parent: "State | None" = None, order: int = 1

--- a/statemachine/io/scxml/actions.py
+++ b/statemachine/io/scxml/actions.py
@@ -159,6 +159,8 @@ def _eval(expr: str, **kwargs) -> Any:
 
 
 class CallableAction:
+    action: Any
+
     def __init__(self):
         self.__qualname__ = f"{self.__class__.__module__}.{self.__class__.__name__}"
 
@@ -373,7 +375,7 @@ def create_send_action_callable(action: SendAction) -> Callable:  # noqa: C901
 
     def send_action(*args, **kwargs):
         machine: StateChart = kwargs["machine"]
-        event = action.event or _eval(action.eventexpr, **kwargs)
+        event = action.event or _eval(action.eventexpr, **kwargs)  # type: ignore[arg-type]
         target = action.target if action.target else None
 
         if action.type and action.type != "http://www.w3.org/TR/scxml/#SCXMLEventProcessor":

--- a/statemachine/io/scxml/processor.py
+++ b/statemachine/io/scxml/processor.py
@@ -97,7 +97,7 @@ class SCXMLProcessor:
                 if isinstance(  # pragma: no branch – always a list from lines above
                     initial_state["enter"], list
                 ):
-                    initial_state["enter"].insert(0, datamodel)
+                    initial_state["enter"].insert(0, datamodel)  # type: ignore[arg-type]
 
         self._add(
             location,

--- a/statemachine/registry.py
+++ b/statemachine/registry.py
@@ -1,3 +1,6 @@
+from typing import List
+from typing import Optional
+
 from .utils import qualname
 
 try:
@@ -29,6 +32,6 @@ def init_registry():
         _initialized = True
 
 
-def load_modules(modules=None):
-    for module in modules:
+def load_modules(modules: Optional[List[str]] = None) -> None:
+    for module in modules or []:
         autodiscover_modules(module)

--- a/statemachine/signature.py
+++ b/statemachine/signature.py
@@ -18,7 +18,7 @@ BindTemplate = Tuple[Tuple[str, ...], Optional[str], Optional[str]]  # noqa: UP0
 
 def _make_key(method):
     method = method.func if isinstance(method, partial) else method
-    if isinstance(method, property):
+    if isinstance(method, property):  # pragma: no cover
         assert method.fget is not None
         method = method.fget
     if isinstance(method, MethodType):

--- a/statemachine/signature.py
+++ b/statemachine/signature.py
@@ -18,7 +18,9 @@ BindTemplate = Tuple[Tuple[str, ...], Optional[str], Optional[str]]  # noqa: UP0
 
 def _make_key(method):
     method = method.func if isinstance(method, partial) else method
-    method = method.fget if isinstance(method, property) else method
+    if isinstance(method, property):
+        assert method.fget is not None
+        method = method.fget
     if isinstance(method, MethodType):
         return hash(
             (

--- a/statemachine/spec_parser.py
+++ b/statemachine/spec_parser.py
@@ -201,6 +201,7 @@ def build_expression(node, variable_hook, operator_mapping):  # noqa: C901
         return reduce(custom_and, expressions)
     elif isinstance(node, ast.Call):
         # Handle function calls
+        assert isinstance(node.func, ast.Name)
         constructor = Functions.get(node.func.id)
         params = [arg.value for arg in node.args if isinstance(arg, ast.Constant)]
         return constructor(*params)

--- a/statemachine/state.py
+++ b/statemachine/state.py
@@ -360,78 +360,86 @@ class InstanceState(State):
         self._machine = ref(machine)
         self._init_states()
 
+    def _ref(self) -> State:
+        """Dereference the weakref, raising if the referent has been collected."""
+        state = self._state()
+        assert state is not None
+        return state
+
     @property
     def name(self):
-        return self._state().name
+        return self._ref().name
 
     @property
     def value(self):
-        return self._state().value
+        return self._ref().value
 
     @property
     def transitions(self):
-        return self._state().transitions
+        return self._ref().transitions
 
     @property
     def enter(self):
-        return self._state().enter
+        return self._ref().enter
 
     @property
     def exit(self):
-        return self._state().exit
+        return self._ref().exit
 
     def __eq__(self, other):
-        return self._state() == other
+        return self._ref() == other
 
     def __hash__(self):
-        return hash(repr(self._state()))
+        return hash(repr(self._ref()))
 
     def __repr__(self):
-        return repr(self._state())
+        return repr(self._ref())
 
     @property
     def initial(self):
-        return self._state()._initial
+        return self._ref()._initial
 
     @property
     def final(self):
-        return self._state()._final
+        return self._ref()._final
 
     @property
     def id(self) -> str:
-        return (self._state() or self)._id
+        return (self._state() or self)._id  # type: ignore[union-attr]
 
     @property
     def is_active(self):
-        return self.value in self._machine().configuration_values
+        machine = self._machine()
+        assert machine is not None
+        return self.value in machine.configuration_values
 
     @property
     def is_atomic(self):
-        return self._state().is_atomic
+        return self._ref().is_atomic
 
     @property
     def parent(self):
-        return self._state().parent
+        return self._ref().parent
 
     @property
     def states(self):
-        return self._state().states
+        return self._ref().states
 
     @property
     def history(self):
-        return self._state().history
+        return self._ref().history
 
     @property
     def parallel(self):
-        return self._state().parallel
+        return self._ref().parallel
 
     @property
     def is_compound(self):
-        return self._state().is_compound
+        return self._ref().is_compound
 
     @property
     def document_order(self):
-        return self._state().document_order
+        return self._ref().document_order
 
 
 class AnyState(State):

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -3,14 +3,18 @@ from inspect import isawaitable
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
+from typing import Generic
 from typing import List
 from typing import MutableSet
+from typing import TypeVar
 
 from statemachine.orderedset import OrderedSet
 
 from .callbacks import SPECS_ALL
 from .callbacks import SPECS_SAFE
+from .callbacks import CallbackSpecList
 from .callbacks import CallbacksRegistry
+from .callbacks import SpecListGrouper
 from .callbacks import SpecReference
 from .dispatcher import Listener
 from .dispatcher import Listeners
@@ -30,9 +34,12 @@ from .utils import run_async_from_sync
 if TYPE_CHECKING:
     from .event import Event
     from .state import State
+    from .states import States
+
+TModel = TypeVar("TModel")
 
 
-class StateChart(metaclass=StateMachineMetaclass):
+class StateChart(Generic[TModel], metaclass=StateMachineMetaclass):
     """
 
     Args:
@@ -97,14 +104,42 @@ class StateChart(metaclass=StateMachineMetaclass):
     If empty (default), the root ``initial`` state will be used.
     """
 
+    # -- Attributes set by StateMachineMetaclass during class construction --
+
+    name: str
+    """The class name of the state machine (e.g. ``"TrafficLightMachine"``)."""
+
+    id: str
+    """Lowercase version of :attr:`name` (e.g. ``"trafficlightmachine"``)."""
+
+    states: "States"
+    """Collection of top-level :ref:`State` objects declared on this class."""
+
+    states_map: Dict[Any, "State"]
+    """Mapping from each state's ``value`` to the corresponding :ref:`State` instance.
+    Includes states at all nesting levels (compound children, parallel regions, etc.)."""
+
+    initial_state: "State | None"
+    """The single top-level initial :ref:`State`, or ``None`` for abstract classes."""
+
+    final_states: "List[State]"
+    """List of top-level :ref:`State` objects marked as ``final``."""
+
+    _abstract: bool
+    _strict_states: bool
+    _events: "Dict[Event, None]"
+    _protected_attrs: set
+    _specs: CallbackSpecList
+    prepare: SpecListGrouper
+
     def __init__(
         self,
-        model: Any = None,
+        model: "TModel | None" = None,
         state_field: str = "state",
         start_value: Any = None,
         listeners: "List[object] | None" = None,
     ):
-        self.model = model if model is not None else Model()
+        self.model: TModel = model if model is not None else Model()  # type: ignore[assignment]
         self.history_values: Dict[
             str, List[State]
         ] = {}  # Mapping of compound states to last active state(s).
@@ -134,13 +169,13 @@ class StateChart(metaclass=StateMachineMetaclass):
 
         return SyncEngine(self)
 
-    def activate_initial_state(self):
+    def activate_initial_state(self) -> Any:
         result = self._engine.activate_initial_state()
         if not isawaitable(result):
             return result
         return run_async_from_sync(result)
 
-    def _processing_loop(self):
+    def _processing_loop(self) -> Any:
         result = self._engine.processing_loop()
         if not isawaitable(result):
             return result
@@ -149,11 +184,6 @@ class StateChart(metaclass=StateMachineMetaclass):
     def __init_subclass__(cls, strict_states: bool = False):
         cls._strict_states = strict_states
         super().__init_subclass__()
-
-    if TYPE_CHECKING:
-        """Makes mypy happy with dynamic created attributes"""
-
-        def __getattr__(self, attribute: str) -> Any: ...
 
     def __repr__(self):
         configuration_ids = [s.id for s in self.configuration]
@@ -169,13 +199,13 @@ class StateChart(metaclass=StateMachineMetaclass):
         del state["_engine"]
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: Dict[str, Any]) -> None:
         listeners = state.pop("_listeners")
-        self.__dict__.update(state)
+        self.__dict__.update(state)  # type: ignore[attr-defined]
         self._callbacks = CallbacksRegistry()
-        self._states_for_instance: Dict[State, State] = {}
+        self._states_for_instance = {}
 
-        self._listeners: Dict[Any, Any] = {}
+        self._listeners = {}
 
         self._register_callbacks([])
         self.add_listener(*listeners.values())
@@ -186,7 +216,7 @@ class StateChart(metaclass=StateMachineMetaclass):
         initial_state_values = (
             self.start_configuration_values
             if self.start_configuration_values
-            else [self.initial_state.value]
+            else [self.initial_state.value]  # type: ignore[union-attr]
         )
         try:
             return [self.states_map[value] for value in initial_state_values]
@@ -263,7 +293,7 @@ class StateChart(metaclass=StateMachineMetaclass):
         return f'<div class="statemachine">{self._repr_svg_()}</div>'
 
     def _repr_svg_(self):
-        return self._graph().create_svg().decode()
+        return self._graph().create_svg().decode()  # type: ignore[attr-defined]
 
     def _graph(self):
         from .contrib.diagram import DotGraphMachine
@@ -392,7 +422,7 @@ class StateChart(metaclass=StateMachineMetaclass):
             for event in state.transitions.unique_events
         ]
 
-    def enabled_events(self, *args, **kwargs):
+    def enabled_events(self, *args, **kwargs) -> Any:
         """List of the current enabled events, considering guard conditions.
 
         An event is **enabled** if at least one of its transitions from the current
@@ -422,7 +452,7 @@ class StateChart(metaclass=StateMachineMetaclass):
         send_id: "str | None" = None,
         internal: bool = False,
         **kwargs,
-    ):
+    ) -> Any:
         """Send an :ref:`Event` to the state machine.
 
         :param event: The trigger for the state machine, specified as an event id string.
@@ -449,7 +479,9 @@ class StateChart(metaclass=StateMachineMetaclass):
             return result
         return run_async_from_sync(result)
 
-    def raise_(self, event: str, *args, delay: float = 0, send_id: "str | None" = None, **kwargs):
+    def raise_(
+        self, event: str, *args, delay: float = 0, send_id: "str | None" = None, **kwargs
+    ) -> Any:
         """Send an :ref:`Event` to the state machine in the internal event queue.
 
         Events on the internal queue are processed immediately within the current

--- a/statemachine/states.py
+++ b/statemachine/states.py
@@ -53,7 +53,7 @@ class States:
     def __eq__(self, other):
         return list(self) == list(other)
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> "State":
         if name in self._states:
             return self._states[name]
         raise AttributeError(f"{name} not found in {self.__class__.__name__}")

--- a/statemachine/utils.py
+++ b/statemachine/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import threading
+from typing import Any
 
 _cached_loop = threading.local()
 """Loop that will be used when the SM is running in a synchronous context. One loop per thread."""
@@ -25,7 +26,7 @@ def ensure_iterable(obj):
         return [obj]
 
 
-def run_async_from_sync(coroutine):
+def run_async_from_sync(coroutine: "Any") -> "Any":
     """
     Compatibility layer to run an async coroutine from a synchronous context.
     """

--- a/tests/examples/enum_campaign_machine.py
+++ b/tests/examples/enum_campaign_machine.py
@@ -37,14 +37,14 @@ class CampaignMachine(StateChart):
 # %%
 # Asserting campaign machine declaration
 
-assert CampaignMachine.DRAFT.initial
-assert not CampaignMachine.DRAFT.final
+assert CampaignMachine.states.DRAFT.initial
+assert not CampaignMachine.states.DRAFT.final
 
-assert not CampaignMachine.PRODUCING.initial
-assert not CampaignMachine.PRODUCING.final
+assert not CampaignMachine.states.PRODUCING.initial
+assert not CampaignMachine.states.PRODUCING.final
 
-assert not CampaignMachine.CLOSED.initial
-assert CampaignMachine.CLOSED.final
+assert not CampaignMachine.states.CLOSED.initial
+assert CampaignMachine.states.CLOSED.final
 
 
 # %%
@@ -53,8 +53,7 @@ assert CampaignMachine.CLOSED.final
 sm = CampaignMachine()
 res = sm.send("produce")
 
-assert sm.DRAFT.is_active is False
-assert sm.PRODUCING.is_active is True
-assert sm.CLOSED.is_active is False
-assert sm.PRODUCING in sm.configuration
+assert CampaignStatus.DRAFT not in sm.configuration_values
+assert CampaignStatus.PRODUCING in sm.configuration_values
+assert CampaignStatus.CLOSED not in sm.configuration_values
 assert CampaignStatus.PRODUCING in sm.configuration_values

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -126,10 +126,10 @@ def test_copy_with_listeners(copy_method):
 def test_copy_with_enum(copy_method):
     sm = GameStateMachine()
     sm.play()
-    assert sm.GAME_PLAYING.is_active
+    assert GameStates.GAME_PLAYING in sm.configuration_values
 
     sm2 = copy_method(sm)
-    assert sm2.GAME_PLAYING.is_active
+    assert GameStates.GAME_PLAYING in sm2.configuration_values
 
 
 def test_copy_with_custom_init_and_vars(copy_method):

--- a/uv.lock
+++ b/uv.lock
@@ -909,6 +909,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144 },
+]
+
+[[package]]
 name = "pytest"
 version = "7.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1099,6 +1113,7 @@ dev = [
     { name = "pillow" },
     { name = "pre-commit" },
     { name = "pydot" },
+    { name = "pyright" },
     { name = "pytest", version = "7.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "8.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-asyncio" },
@@ -1131,6 +1146,7 @@ dev = [
     { name = "pillow", marker = "python_full_version >= '3.9'" },
     { name = "pre-commit" },
     { name = "pydot" },
+    { name = "pyright", specifier = ">=1.1.400" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },


### PR DESCRIPTION
## Summary

Closes #515

- **pyright support**: added as dev dependency + pre-commit hook (basic mode, Python 3.9 target). All 38 baseline errors fixed — `uv run pyright statemachine/` passes clean.
- **`Generic[TModel]`**: `StateChart` is now generic over its model type. `sm.model` gets full type inference and IDE autocompletion when declared as `StateChart[MyModel]`. Without a type parameter, defaults to `Any` (backward compatible).
- **Removed `__getattr__` catch-all**: the `TYPE_CHECKING` stubs that returned `Any` on both `StateChart` and `StateMachineMetaclass` are gone. Type checkers now detect misspelled attributes and unresolved references on subclasses.
- **Explicit metaclass attribute declarations**: `name`, `id`, `states`, `states_map`, `initial_state`, `final_states` are declared with docstrings on `StateChart` so type checkers see them without a catch-all fallback.
- **Return type annotations**: added to `send()`, `raise_()`, `enabled_events()`, `activate_initial_state()`, `Event.__call__()`, `run_async_from_sync()`, `States.__getattr__()`.
- **Documentation**: new "Typed models" section in `docs/models.md` with executable doctest, and two new entries in `docs/releases/3.0.0.md` (typed models + pyright support).