### PR TITLE
feat: future-based result routing for async concurrent events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,15 @@ uv run mypy statemachine/ tests/
 
 ## Design principles
 
+- **Follow SOLID principles.** In particular:
+  - **Law of Demeter:** Methods should depend only on the data they need, not on the
+    objects that contain it. Pass the specific value (e.g., a `Future`) rather than the
+    parent object (e.g., `TriggerData`) — this reduces coupling and removes the need for
+    null-checks on intermediate accessors.
+  - **Single Responsibility:** Each module, class, and function should have one clear reason
+    to change.
+  - **Interface Segregation:** Depend on narrow interfaces. If a helper only needs one field
+    from a dataclass, accept that field directly.
 - **Decouple infrastructure from domain:** Modules like `signature.py` and `dispatcher.py` are
   general-purpose (signature adaptation, listener/observer pattern) and intentionally not coupled
   to the state machine domain. Prefer this separation even for modules that are only used
@@ -162,6 +171,13 @@ uv run sphinx-build docs docs/_build/html
 # Live reload for development
 uv run sphinx-autobuild docs docs/_build/html --re-ignore "auto_examples/.*"
 ```
+
+### Documentation code examples
+
+All code examples in `docs/*.md` **must** be testable doctests (using ```` ```py ```` with
+`>>>` prompts), not plain ```` ```python ```` blocks. The test suite collects them via
+`--doctest-glob=*.md`. If an example cannot be expressed as a doctest (e.g., it requires
+real concurrency), write it as a unit test in `tests/` and reference it from the docs instead.
 
 ## Git workflow
 

--- a/docs/async.md
+++ b/docs/async.md
@@ -193,11 +193,16 @@ compound states, parallel states, history pseudo-states, eventless transitions,
 and `done.state` events — are fully supported in async code. The same
 `activate_initial_state()` pattern applies:
 
-```python
-async def run():
-    sm = MyStateChart()
-    await sm.activate_initial_state()
-    await sm.send("event")
+```py
+>>> async def run():
+...     sm = AsyncStateMachine()
+...     await sm.activate_initial_state()
+...     result = await sm.send("advance")
+...     return result
+
+>>> asyncio.run(run())
+42
+
 ```
 
 ### Concurrent event sending

--- a/docs/async.md
+++ b/docs/async.md
@@ -200,6 +200,62 @@ async def run():
     await sm.send("event")
 ```
 
+### Concurrent event sending
+
+```{versionadded} 3.0.0
+```
+
+When multiple coroutines send events concurrently (e.g., via `asyncio.gather`),
+each caller receives its own event's result — even though only one coroutine
+actually runs the processing loop at a time.
+
+```py
+>>> class ConcurrentSC(StateChart):
+...     s1 = State(initial=True)
+...     s2 = State()
+...     s3 = State(final=True)
+...
+...     step1 = s1.to(s2)
+...     step2 = s2.to(s3)
+...
+...     async def on_step1(self):
+...         return "result_1"
+...
+...     async def on_step2(self):
+...         return "result_2"
+
+>>> async def run_concurrent():
+...     import asyncio as _asyncio
+...     sm = ConcurrentSC()
+...     await sm.activate_initial_state()
+...     r1, r2 = await _asyncio.gather(
+...         sm.send("step1"),
+...         sm.send("step2"),
+...     )
+...     return r1, r2
+
+>>> asyncio.run(run_concurrent())
+('result_1', 'result_2')
+
+```
+
+Under the hood, the async engine attaches an `asyncio.Future` to each
+externally enqueued event. The coroutine that acquires the processing lock
+resolves each event's future as it processes the queue. Callers that couldn't
+acquire the lock simply `await` their future.
+
+```{note}
+Futures are only created for **external** events sent from outside the
+processing loop. Events triggered from within callbacks (reentrant calls)
+follow the existing run-to-completion (RTC) model — they are enqueued and
+processed within the current macrostep, and the callback receives ``None``.
+```
+
+If an exception occurs during processing (with `error_on_execution=False`),
+the exception is routed to the caller whose event caused it. Other callers
+whose events were still pending will also receive the exception, since the
+processing loop clears the queue on failure.
+
 ### Async-specific limitations
 
 - **Initial state activation**: In async code, you must `await sm.activate_initial_state()`

--- a/docs/releases/3.0.0.md
+++ b/docs/releases/3.0.0.md
@@ -410,6 +410,19 @@ class GameCharacter(StateChart):
 See {ref}`weighted-transitions` for full documentation.
 
 
+### Async concurrent event result routing
+
+When multiple coroutines send events concurrently via `asyncio.gather`, each
+caller now receives its own event's result (or exception). Previously, only the
+first caller to acquire the processing lock would get a result — subsequent
+callers received `None` and exceptions could leak to the wrong caller.
+
+This is implemented by attaching an `asyncio.Future` to each externally
+enqueued event in the async engine. See {ref}`async` for details.
+
+Fixes [#509](https://github.com/fgmacedo/python-statemachine/issues/509).
+
+
 ## Bugfixes in 3.0.0
 
 - Fixes [#XXX](https://github.com/fgmacedo/python-statemachine/issues/XXX).

--- a/statemachine/engines/async_.py
+++ b/statemachine/engines/async_.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import logging
 from itertools import chain
 from time import time
@@ -21,12 +22,62 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# ContextVar to distinguish reentrant calls (from within callbacks) from
+# concurrent external calls. asyncio propagates context to child tasks
+# (e.g., those created by asyncio.gather in the callback system), so a
+# ContextVar set in the processing loop is visible in all callbacks.
+# Independent external coroutines have their own context where this is False.
+_in_processing_loop: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_in_processing_loop", default=False
+)
+
+
 class AsyncEngine(BaseEngine):
     """Async engine with full StateChart support.
 
     Mirrors :class:`SyncEngine` algorithm but uses ``async``/``await`` for callback dispatch.
     All pure-computation helpers are inherited from :class:`BaseEngine`.
     """
+
+    def put(self, trigger_data: TriggerData, internal: bool = False, _delayed: bool = False):
+        """Override to attach an asyncio.Future for external events.
+
+        Futures are only created when:
+        - The event is external (not internal)
+        - No future is already attached
+        - There is a running asyncio loop
+        - The call is NOT from within the processing loop (reentrant calls
+          from callbacks must not get futures, as that would deadlock)
+        """
+        if not internal and trigger_data.future is None and not _in_processing_loop.get():
+            try:
+                loop = asyncio.get_running_loop()
+                trigger_data.future = loop.create_future()
+            except RuntimeError:
+                pass  # No running loop — sync caller
+        super().put(trigger_data, internal=internal, _delayed=_delayed)
+
+    @staticmethod
+    def _resolve_future(future: "asyncio.Future[object] | None", result):
+        """Resolve a future with the given result, if present and not yet done."""
+        if future is not None and not future.done():
+            future.set_result(result)
+
+    @staticmethod
+    def _reject_future(future: "asyncio.Future[object] | None", exc: Exception):
+        """Reject a future with the given exception, if present and not yet done."""
+        if future is not None and not future.done():
+            future.set_exception(exc)
+
+    def _reject_pending_futures(self, exc: Exception):
+        """Reject all unresolved futures in the external queue.
+
+        Called when the processing loop exits abnormally so that coroutines
+        awaiting their futures don't hang forever.
+        """
+        with self.external_queue.queue.mutex:
+            for trigger_data in self.external_queue.queue.queue:
+                self._reject_future(trigger_data.future, exc)
 
     # --- Callback dispatch overrides (async versions of BaseEngine methods) ---
 
@@ -265,16 +316,27 @@ class AsyncEngine(BaseEngine):
         """
         return await self.processing_loop()
 
-    async def processing_loop(self):  # noqa: C901
+    async def processing_loop(  # noqa: C901
+        self, caller_future: "asyncio.Future[object] | None" = None
+    ):
         """Process event triggers with the 3-phase macrostep architecture.
 
         Phase 1: Eventless transitions + internal queue until quiescence.
         Phase 2: Remaining internal events (safety net for invoke-generated events).
         Phase 3: External events.
+
+        When ``caller_future`` is provided, the caller can ``await`` it to
+        receive its own event's result — even if another coroutine holds the
+        processing lock.
         """
         if not self._processing.acquire(blocking=False):
+            # Another coroutine holds the lock and will process our event.
+            # Await the caller's future so we get our own result back.
+            if caller_future is not None:
+                return await caller_future
             return None
 
+        _ctx_token = _in_processing_loop.set(True)
         logger.debug("Processing loop started: %s", self.sm.current_state_value)
         first_result = self._sentinel
         try:
@@ -336,26 +398,53 @@ class AsyncEngine(BaseEngine):
                         )
                         break
 
-                    enabled_transitions = await self.select_transitions(external_event)
-                    logger.debug("Enabled transitions: %s", enabled_transitions)
-                    if enabled_transitions:
-                        try:
+                    event_future = external_event.future
+                    try:
+                        enabled_transitions = await self.select_transitions(external_event)
+                        logger.debug("Enabled transitions: %s", enabled_transitions)
+                        if enabled_transitions:
                             result = await self.microstep(
                                 list(enabled_transitions), external_event
                             )
+                            self._resolve_future(event_future, result)
                             if first_result is self._sentinel:
                                 first_result = result
-                        except Exception:
-                            self.clear()
-                            raise
+                        else:
+                            if not self.sm.allow_event_without_transition:
+                                tna = TransitionNotAllowed(
+                                    external_event.event, self.sm.configuration
+                                )
+                                self._reject_future(event_future, tna)
+                                self._reject_pending_futures(tna)
+                                raise tna
+                            # Event allowed but no transition — resolve with None
+                            self._resolve_future(event_future, None)
+                    except Exception as exc:
+                        self._reject_future(event_future, exc)
+                        self._reject_pending_futures(exc)
+                        self.clear()
+                        raise
 
-                    else:
-                        if not self.sm.allow_event_without_transition:
-                            raise TransitionNotAllowed(external_event.event, self.sm.configuration)
-
+        except Exception as exc:
+            if caller_future is not None:
+                # Route the exception to the caller's future if still pending.
+                # If already resolved (caller's own event succeeded before a
+                # later event failed), suppress the exception — the caller will
+                # get their successful result via ``await future`` below, and
+                # the failing event's exception was already routed to *its*
+                # caller's future by ``_reject_future(event_future, ...)``.
+                self._reject_future(caller_future, exc)
+            else:
+                raise
         finally:
+            _in_processing_loop.reset(_ctx_token)
             self._processing.release()
-        return first_result if first_result is not self._sentinel else None
+
+        result = first_result if first_result is not self._sentinel else None
+        # If the caller has a future, await it (already resolved by now).
+        if caller_future is not None:
+            return await caller_future
+        return result
 
     async def enabled_events(self, *args, **kwargs):
         sm = self.sm

--- a/statemachine/engines/async_.py
+++ b/statemachine/engines/async_.py
@@ -70,14 +70,8 @@ class AsyncEngine(BaseEngine):
             future.set_exception(exc)
 
     def _reject_pending_futures(self, exc: Exception):
-        """Reject all unresolved futures in the external queue.
-
-        Called when the processing loop exits abnormally so that coroutines
-        awaiting their futures don't hang forever.
-        """
-        with self.external_queue.queue.mutex:
-            for trigger_data in self.external_queue.queue.queue:
-                self._reject_future(trigger_data.future, exc)
+        """Reject all unresolved futures in the external queue."""
+        self.external_queue.reject_futures(exc)
 
     # --- Callback dispatch overrides (async versions of BaseEngine methods) ---
 

--- a/statemachine/engines/base.py
+++ b/statemachine/engines/base.py
@@ -59,6 +59,18 @@ class EventQueue:
         with self.queue.mutex:
             self.queue.queue.clear()
 
+    def reject_futures(self, exc: Exception):
+        """Reject all unresolved futures in the queue.
+
+        Called when the processing loop exits abnormally so that coroutines
+        awaiting their futures don't hang forever.
+        """
+        with self.queue.mutex:
+            for trigger_data in self.queue.queue:
+                future = trigger_data.future
+                if future is not None and not future.done():
+                    future.set_exception(exc)
+
     def remove(self, send_id: str):
         # We use the internal `queue` to make thins faster as the mutex
         # is protecting the block below

--- a/statemachine/engines/sync.py
+++ b/statemachine/engines/sync.py
@@ -57,7 +57,7 @@ class SyncEngine(BaseEngine):
                 self._processing.release()
         return self.processing_loop()
 
-    def processing_loop(self):  # noqa: C901
+    def processing_loop(self, caller_future=None):  # noqa: C901
         """Process event triggers.
 
         The event is put on a queue, and only the first event will have the result collected.

--- a/statemachine/event.py
+++ b/statemachine/event.py
@@ -156,8 +156,8 @@ class Event(AddCallbacksMixin, str):
         # can be called as a method. But it is not meant to be called without
         # an SM instance. Such SM instance is provided by `__get__` method when
         # used as a property descriptor.
-        self.put(*args, **kwargs)
-        return self._sm._processing_loop()  # type: ignore[union-attr]
+        trigger_data = self.put(*args, **kwargs)
+        return self._sm._processing_loop(trigger_data.future)  # type: ignore[union-attr]
 
     def split(  # type: ignore[override]
         self, sep: "str | None" = None, maxsplit: int = -1

--- a/statemachine/event_data.py
+++ b/statemachine/event_data.py
@@ -36,6 +36,13 @@ class TriggerData:
     kwargs: dict = field(default_factory=dict, compare=False)
     """All keyword arguments provided on the :ref:`Event`."""
 
+    future: Any = field(default=None, compare=False, repr=False, init=False)
+    """An optional :class:`asyncio.Future` for async result routing.
+
+    When set, the processing loop will resolve this future with the microstep
+    result (or exception), allowing the caller to ``await`` it.
+    """
+
     def __post_init__(self):
         self.model = self.machine.model
         delay = self.event.delay if self.event and self.event.delay else 0

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -175,8 +175,8 @@ class StateChart(Generic[TModel], metaclass=StateMachineMetaclass):
             return result
         return run_async_from_sync(result)
 
-    def _processing_loop(self) -> Any:
-        result = self._engine.processing_loop()
+    def _processing_loop(self, caller_future: "Any | None" = None) -> Any:
+        result = self._engine.processing_loop(caller_future)
         if not isawaitable(result):
             return result
         return run_async_from_sync(result)

--- a/tests/test_async_futures.py
+++ b/tests/test_async_futures.py
@@ -10,6 +10,8 @@ See: https://github.com/fgmacedo/python-statemachine/issues/509
 import asyncio
 
 import pytest
+from statemachine.engines.base import EventQueue
+from statemachine.event_data import TriggerData
 
 from statemachine import State
 from statemachine import StateChart
@@ -320,3 +322,20 @@ class TestFutureEdgeCases:
         assert results["fn1"] == "noop ok"
         assert "fn2" in errors
         assert str(errors["fn2"]) == "noop2 is not allowed"
+
+
+class TestEventQueueRejectFutures:
+    """Unit tests for EventQueue.reject_futures."""
+
+    def test_reject_futures_skips_items_without_future(self):
+        """Items with future=None are silently skipped."""
+        sm = TrafficLight()
+
+        queue = EventQueue()
+        td = TriggerData(machine=sm, event=None)
+        assert td.future is None
+        queue.put(td)
+
+        queue.reject_futures(RuntimeError("boom"))
+        # No exception raised, item still in queue
+        assert not queue.is_empty()

--- a/tests/test_async_futures.py
+++ b/tests/test_async_futures.py
@@ -1,0 +1,322 @@
+"""Tests for future-based result routing in the async engine.
+
+When multiple coroutines send events concurrently, only one acquires the
+processing lock. The others must still receive their own event's result (or
+exception) via an ``asyncio.Future`` attached to each ``TriggerData``.
+
+See: https://github.com/fgmacedo/python-statemachine/issues/509
+"""
+
+import asyncio
+
+import pytest
+
+from statemachine import State
+from statemachine import StateChart
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+class TrafficLight(StateChart):
+    green = State(initial=True)
+    yellow = State()
+    red = State()
+
+    slow_down = green.to(yellow)
+    stop = yellow.to(red)
+    go = red.to(green)
+
+    async def on_slow_down(self):
+        return "slowing"
+
+    async def on_stop(self):
+        return "stopped"
+
+    async def on_go(self):
+        return "going"
+
+
+class FailingMachine(StateChart):
+    s1 = State(initial=True)
+    s2 = State()
+    s3 = State()
+
+    ok = s1.to(s2)
+    fail = s2.to(s3)
+
+    async def on_ok(self):
+        return "ok_result"
+
+    async def on_fail(self):
+        raise RuntimeError("boom")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentSendsGetCorrectResults:
+    """asyncio.gather(sm.send("a"), sm.send("b")) — each caller gets its own result."""
+
+    @pytest.mark.asyncio()
+    async def test_sequential_sends(self):
+        """Baseline: sequential sends return correct results."""
+        sm = TrafficLight()
+        await sm.activate_initial_state()
+
+        r1 = await sm.send("slow_down")
+        assert r1 == "slowing"
+
+        r2 = await sm.send("stop")
+        assert r2 == "stopped"
+
+    @pytest.mark.asyncio()
+    async def test_single_async_caller_gets_result(self):
+        """Single async caller gets its callback result (backward compat)."""
+        sm = TrafficLight()
+        await sm.activate_initial_state()
+
+        result = await sm.slow_down()
+        assert result == "slowing"
+
+
+class TestExceptionRouting:
+    """Exceptions from one event must be routed to the correct caller."""
+
+    @pytest.mark.asyncio()
+    async def test_exception_reaches_caller(self):
+        """When error_on_execution=False (not default for StateChart), the
+        exception propagates to the caller of that event."""
+
+        class FailingSC(StateChart):
+            error_on_execution = False
+            s1 = State(initial=True)
+            s2 = State()
+            go = s1.to(s2)
+
+            async def on_go(self):
+                raise ValueError("broken")
+
+        sm = FailingSC()
+        await sm.activate_initial_state()
+
+        with pytest.raises(ValueError, match="broken"):
+            await sm.send("go")
+
+
+class TestTransitionNotAllowedRouting:
+    """TransitionNotAllowed from an unknown event reaches the correct caller."""
+
+    @pytest.mark.asyncio()
+    async def test_transition_not_allowed(self):
+        class StrictSC(StateChart):
+            allow_event_without_transition = False
+            s1 = State(initial=True)
+            s2 = State()
+            go = s1.to(s2)
+
+            async def on_go(self):
+                return "went"
+
+        sm = StrictSC()
+        await sm.activate_initial_state()
+
+        # "go" works
+        result = await sm.send("go")
+        assert result == "went"
+
+        # Now in s2, "go" has no transition
+        with pytest.raises(sm.TransitionNotAllowed):
+            await sm.send("go")
+
+
+class TestFutureEdgeCases:
+    """Edge cases for future-based routing."""
+
+    @pytest.mark.asyncio()
+    async def test_initial_activation_no_future(self):
+        """activate_initial_state has no caller_trigger, should work fine."""
+        sm = TrafficLight()
+        await sm.activate_initial_state()
+        assert "green" in sm.configuration_values
+
+    @pytest.mark.asyncio()
+    async def test_allow_event_without_transition_resolves_none(self):
+        """When allow_event_without_transition=True and no transition matches,
+        the caller should get None (not hang)."""
+        sm = TrafficLight()
+        await sm.activate_initial_state()
+
+        # "stop" is not valid from "green", but allow_event_without_transition=True
+        result = await sm.send("stop")
+        assert result is None
+
+    @pytest.mark.asyncio()
+    async def test_concurrent_sends_via_gather(self):
+        """Two coroutines sending events concurrently via asyncio.gather.
+
+        One coroutine will hold the lock; the other awaits its future.
+        Both should get their own results.
+        """
+
+        class SlowMachine(StateChart):
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+
+            step1 = s1.to(s2)
+            step2 = s2.to(s3)
+
+            async def on_step1(self):
+                # Yield control so the second coroutine can enqueue its event
+                await asyncio.sleep(0)
+                return "result_1"
+
+            async def on_step2(self):
+                return "result_2"
+
+        sm = SlowMachine()
+        await sm.activate_initial_state()
+
+        r1, r2 = await asyncio.gather(
+            sm.send("step1"),
+            sm.send("step2"),
+        )
+
+        assert r1 == "result_1"
+        assert r2 == "result_2"
+
+    @pytest.mark.asyncio()
+    async def test_concurrent_sends_exception_with_error_on_execution_off(self):
+        """When error_on_execution=False and one event raises, the exception
+        is routed to that caller's future; the other caller is unaffected.
+
+        With error_on_execution=False, the exception propagates and the
+        processing loop clears the external queue, so the second event is
+        never processed.
+        """
+
+        class ConcurrentFailMachine(StateChart):
+            error_on_execution = False
+            s1 = State(initial=True)
+            s2 = State()
+            s3 = State()
+
+            step1 = s1.to(s2)
+            step2 = s2.to(s3)
+
+            async def on_step1(self):
+                await asyncio.sleep(0)
+                raise RuntimeError("step1 failed")
+
+            async def on_step2(self):
+                return "step2_ok"
+
+        sm = ConcurrentFailMachine()
+        await sm.activate_initial_state()
+
+        # step1 raises — the exception should reach step1's caller via its future.
+        # step2 was queued but the processing loop rejects all pending futures
+        # and clears the queue on exception.
+        r1, r2 = await asyncio.gather(
+            sm.send("step1"),
+            sm.send("step2"),
+            return_exceptions=True,
+        )
+
+        # step1's caller gets the RuntimeError
+        assert isinstance(r1, RuntimeError)
+        assert str(r1) == "step1 failed"
+        # step2 also gets the RuntimeError (pending future rejected with same exception)
+        assert isinstance(r2, RuntimeError)
+        assert str(r2) == "step1 failed"
+
+    @pytest.mark.asyncio()
+    async def test_separate_tasks_with_slow_callback(self):
+        """Reproduces the scenario from issue #509: two separate asyncio tasks
+        send events to the same state machine. The first callback does a slow
+        ``await asyncio.sleep()``, yielding control so the second task can
+        enqueue its event. Both tasks must receive their own results.
+
+        This specifically tests that concurrent external tasks (as opposed to
+        reentrant calls from within callbacks) correctly get futures and don't
+        return ``None``.
+        """
+
+        class SlowSC(StateChart):
+            s1 = State(initial=True)
+            s2 = State()
+
+            noop = s1.to(s2)
+            noop2 = s2.to.itself()
+
+            async def on_noop(self, name):
+                await asyncio.sleep(0.01)
+                return f"noop done by {name}"
+
+            async def on_noop2(self, name):
+                return f"noop2 done by {name}"
+
+        sm = SlowSC()
+        await sm.activate_initial_state()
+
+        results = {}
+
+        async def fn1():
+            results["fn1"] = await sm.send("noop", "fn1")
+
+        async def fn2():
+            # Small delay so fn1 acquires the lock first
+            await asyncio.sleep(0.005)
+            results["fn2"] = await sm.send("noop2", "fn2")
+
+        await asyncio.gather(fn1(), fn2())
+
+        assert results["fn1"] == "noop done by fn1"
+        assert results["fn2"] == "noop2 done by fn2"
+
+    @pytest.mark.asyncio()
+    async def test_separate_tasks_validator_exception_routing(self):
+        """Issue #509 scenario: validator exception must reach the correct
+        caller task, not the task that holds the processing lock.
+        """
+
+        class ValidatorSC(StateChart):
+            error_on_execution = False
+            s1 = State(initial=True)
+            s2 = State()
+
+            noop = s1.to(s2)
+            noop2 = s2.to.itself(validators="check_allowed")
+
+            async def on_noop(self):
+                await asyncio.sleep(0.01)
+                return "noop ok"
+
+            def check_allowed(self):
+                raise ValueError("noop2 is not allowed")
+
+        sm = ValidatorSC()
+        await sm.activate_initial_state()
+
+        results = {}
+        errors = {}
+
+        async def fn1():
+            results["fn1"] = await sm.send("noop")
+
+        async def fn2():
+            await asyncio.sleep(0.005)
+            try:
+                await sm.send("noop2")
+            except ValueError as e:
+                errors["fn2"] = e
+
+        await asyncio.gather(fn1(), fn2())
+
+        assert results["fn1"] == "noop ok"
+        assert "fn2" in errors
+        assert str(errors["fn2"]) == "noop2 is not allowed"

--- a/tests/testcases/test_issue509.py
+++ b/tests/testcases/test_issue509.py
@@ -31,7 +31,7 @@ class Issue509SC(StateChart):
     )
 
     async def do_nothing(self, name):
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.01)
         return f"Did nothing via {name}"
 
     def raise_exception(self):

--- a/tests/testcases/test_issue509.py
+++ b/tests/testcases/test_issue509.py
@@ -1,0 +1,65 @@
+"""
+
+### Issue 509
+
+A StateChart that exercises the example given on issue
+#[509](https://github.com/fgmacedo/python-statemachine/issues/509).
+
+When multiple async coroutines send events concurrently, each caller should
+receive its own event's result or exception — not another caller's.
+
+Original problem: fn2 triggers a validator exception, but fn1 receives it instead.
+"""
+
+import asyncio
+
+import pytest
+
+from statemachine import State
+from statemachine import StateChart
+
+
+class Issue509SC(StateChart):
+    error_on_execution = False
+
+    INITIAL = State(initial=True)
+    FINAL = State()
+
+    noop = INITIAL.to(FINAL, on="do_nothing")
+    noop2 = INITIAL.to(FINAL, on="do_nothing", validators="raise_exception") | FINAL.to.itself(
+        on="do_nothing", validators="raise_exception"
+    )
+
+    async def do_nothing(self, name):
+        await asyncio.sleep(0.1)
+        return f"Did nothing via {name}"
+
+    def raise_exception(self):
+        raise ValueError("noop2 is not allowed")
+
+
+@pytest.mark.asyncio()
+async def test_issue509_exception_routed_to_correct_caller():
+    test = Issue509SC()
+    await test.activate_initial_state()
+
+    results = {}
+
+    async def fn1():
+        results["fn1"] = await test.send("noop", "fn1")
+
+    async def fn2():
+        try:
+            await test.send("noop2", "fn2")
+            results["fn2"] = "no error"
+        except ValueError as e:
+            results["fn2"] = f"caught: {e}"
+
+    task1 = asyncio.create_task(fn1())
+    task2 = asyncio.create_task(fn2())
+    await asyncio.gather(task1, task2)
+
+    # fn1 should get its own result, not fn2's exception
+    assert results["fn1"] == "Did nothing via fn1"
+    # fn2 should catch the ValueError from its own validator
+    assert results["fn2"] == "caught: noop2 is not allowed"


### PR DESCRIPTION
## Summary

- Fixes #509: when multiple coroutines send events concurrently, each caller now receives its own event's result (or exception) via an `asyncio.Future`, instead of non-lock-holding callers silently returning `None`
- Uses `contextvars.ContextVar` to distinguish reentrant callback calls (which must NOT get futures to avoid deadlocks) from concurrent external calls (which need futures for correct routing)
- Follows Law of Demeter: helper methods accept the `Future` directly rather than reaching through `TriggerData`

### Changes

| File | What |
|------|------|
| `event_data.py` | `future` field on `TriggerData` |
| `event.py` | Pass `trigger_data.future` to `_processing_loop` |
| `statemachine.py` | `caller_future` parameter on `_processing_loop` |
| `engines/async_.py` | ContextVar, `put()` override, future resolve/reject, rewritten `processing_loop` |
| `engines/sync.py` | `caller_future` param for API consistency (no behavior change) |
| `tests/test_async_futures.py` | 10 new tests for concurrent result routing |
| `docs/async.md` | "Concurrent event sending" section with doctest |
| `docs/releases/3.0.0.md` | Release note |
