### PR TITLE
Rename error_on_execution to catch_errors_as_events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,9 @@ The engine follows the SCXML run-to-completion (RTC) model with two processing l
 - `send()` → **external queue** (processed after current macrostep ends).
 - `raise_()` → **internal queue** (processed within the current macrostep, before external events).
 
-### Error handling (`error_on_execution`)
+### Error handling (`catch_errors_as_events`)
 
-- `StateChart` has `error_on_execution=True` by default; `StateMachine` has `False`.
+- `StateChart` has `catch_errors_as_events=True` by default; `StateMachine` has `False`.
 - Errors are caught at the **block level** (per onentry/onexit/transition `on` block), not per
   microstep. This means `after` callbacks still run even when an action raises — making
   `after_<event>()` a natural **finalize** hook (runs on both success and failure paths).

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -69,7 +69,7 @@ The `state` column shows what the `state` parameter resolves to when
 
 ```{tip}
 `after` callbacks run even when an earlier group raises and
-`error_on_execution` is enabled — making them a natural **finalize** hook.
+`catch_errors_as_events` is enabled — making them a natural **finalize** hook.
 See {ref}`error-handling-cleanup-finalize` for the full pattern.
 ```
 

--- a/docs/async.md
+++ b/docs/async.md
@@ -161,7 +161,7 @@ processing loop. Events triggered from within callbacks (via `send()` or
 are enqueued and processed within the current macrostep.
 ```
 
-If an exception occurs during processing (with `error_on_execution=False`),
+If an exception occurs during processing (with `catch_errors_as_events=False`),
 the exception is routed to the caller whose event caused it. Other callers
 whose events were still pending will also receive the exception, since the
 processing loop clears the queue on failure.

--- a/docs/behaviour.md
+++ b/docs/behaviour.md
@@ -33,7 +33,7 @@ SCXML-compliant behavior provides more predictable semantics.
 | `allow_event_without_transition` | `True` | `False` | Tolerate events that don't match any transition |
 | `enable_self_transition_entries` | `True` | `False` | Execute entry/exit actions on self-transitions |
 | `atomic_configuration_update` | `False` | `True` | When to update {ref}`configuration <querying-configuration>` during a microstep |
-| `error_on_execution` | `True` | `False` | Catch action errors as `error.execution` events |
+| `catch_errors_as_events` | `True` | `False` | Catch action errors as `error.execution` events |
 
 Each attribute is described below, with cross-references to the pages that
 cover the topic in depth.
@@ -142,7 +142,7 @@ in callbacks.
 ```
 
 
-## `error_on_execution`
+## `catch_errors_as_events`
 
 When `True` (SCXML default), runtime exceptions in action callbacks
 (entry/exit, transition `on`) are caught by the engine and dispatched as
@@ -152,7 +152,7 @@ propagate normally to the caller.
 ```{note}
 {ref}`Validators <validators>` are **not** affected by this flag — they
 always propagate exceptions to the caller, regardless of the
-`error_on_execution` setting. See {ref}`validators` for details.
+`catch_errors_as_events` setting. See {ref}`validators` for details.
 ```
 
 ```{seealso}
@@ -168,7 +168,7 @@ adopt SCXML semantics incrementally in an existing `StateMachine`:
 
 ```python
 class MyMachine(StateMachine):
-    error_on_execution = True
+    catch_errors_as_events = True
     # ... everything else behaves as before ...
 ```
 

--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -15,7 +15,7 @@ failures by transitioning to an error state, retrying, or recovering. This
 follows the [SCXML error handling specification](https://www.w3.org/TR/scxml/#errorsAndEvents).
 
 ```{tip}
-`error_on_execution` is a class attribute that controls this behavior.
+`catch_errors_as_events` is a class attribute that controls this behavior.
 `StateChart` uses `True` by default (SCXML-compliant); set it to `False`
 to let exceptions propagate to the caller instead. See {ref}`behaviour`
 for the full comparison of behavioral attributes and how to customize them.
@@ -226,7 +226,7 @@ more detailed version of this pattern with annotated output.
 {ref}`Validators <validators>` operate in the **transition-selection** phase,
 before any state changes occur. Their exceptions **always propagate** to the
 caller — they are never caught by the engine and never converted to
-`error.execution` events, regardless of the `error_on_execution` setting.
+`error.execution` events, regardless of the `catch_errors_as_events` setting.
 
 This is intentional: a validator rejection means the transition should not
 happen at all. It is semantically equivalent to a condition returning
@@ -240,7 +240,7 @@ propagation.
 
 ```{seealso}
 See {ref}`behaviour` for the full comparison of behavioral attributes
-and how to customize `error_on_execution` and other settings.
+and how to customize `catch_errors_as_events` and other settings.
 See {ref}`actions` for the callback execution order within each
 microstep.
 ```

--- a/docs/events.md
+++ b/docs/events.md
@@ -305,7 +305,7 @@ on a non-final state raises `InvalidDefinition`.
 ### `error.execution` events
 
 When a callback raises during a macrostep and
-{ref}`error_on_execution <behaviour>` is enabled, the engine dispatches an
+{ref}`catch_errors_as_events <behaviour>` is enabled, the engine dispatches an
 `error.execution` internal event. Define a transition for this event to
 recover from errors within the statechart:
 

--- a/docs/guards.md
+++ b/docs/guards.md
@@ -293,13 +293,13 @@ True
 ### Validators always propagate
 
 Validator exceptions **always propagate** to the caller, regardless of the
-`error_on_execution` flag. This is intentional: validators operate in the
+`catch_errors_as_events` flag. This is intentional: validators operate in the
 **transition-selection** phase, not the execution phase. A validator that
 rejects is semantically equivalent to a condition that returns `False` —
 the transition simply should not happen. The difference is that the
 validator communicates the reason via an exception.
 
-This means that even when `error_on_execution = True` (the default for
+This means that even when `catch_errors_as_events = True` (the default for
 `StateChart`):
 
 - Validator exceptions are **not** converted to `error.execution` events.

--- a/docs/invoke.md
+++ b/docs/invoke.md
@@ -343,7 +343,7 @@ True
 ## Error handling
 
 If an invoke handler raises an exception, `error.execution` is sent to the machine's
-internal queue (when `error_on_execution=True`, the default for `StateChart`). You can
+internal queue (when `catch_errors_as_events=True`, the default for `StateChart`). You can
 handle it with a transition for `error.execution`:
 
 ```py

--- a/docs/processing_model.md
+++ b/docs/processing_model.md
@@ -47,7 +47,7 @@ callback groups defined in the {ref}`execution order <actions>`:
 8. **After** — run post-transition callbacks (always runs, even on error).
 
 ```{tip}
-If an error occurs during steps 3–6 and `error_on_execution` is enabled,
+If an error occurs during steps 3–6 and `catch_errors_as_events` is enabled,
 the error is caught at the **block level** — remaining actions in that block
 are skipped, but the microstep continues. See
 {ref}`error-execution` and the

--- a/docs/releases/3.0.0.md
+++ b/docs/releases/3.0.0.md
@@ -293,7 +293,7 @@ Existing calls to `send()` are fully backward compatible.
 
 ### Error handling with `error.execution`
 
-When `error_on_execution` is enabled (default in `StateChart`), runtime exceptions during
+When `catch_errors_as_events` is enabled (default in `StateChart`), runtime exceptions during
 transitions are caught and result in an internal `error.execution` event. This follows
 the [SCXML error handling specification](https://www.w3.org/TR/scxml/#errorsAndEvents).
 
@@ -458,7 +458,7 @@ machines can receive context at creation time:
 #### `StateChart` base class
 
 The new `StateChart` class is the recommended base for all new state machines. It enables
-SCXML-compliant defaults: `error_on_execution`, `enable_self_transition_entries`, and
+SCXML-compliant defaults: `catch_errors_as_events`, `enable_self_transition_entries`, and
 non-atomic configuration updates. The existing `StateMachine` class is now a subclass with
 backward-compatible defaults. See {ref}`behaviour` for a comparison table.
 

--- a/docs/releases/upgrade_2x_to_3.md
+++ b/docs/releases/upgrade_2x_to_3.md
@@ -56,7 +56,7 @@ now a subclass of `StateChart` with defaults that preserve 2.x behavior:
 | `allow_event_without_transition`  | `True`       | `False`        |
 | `enable_self_transition_entries`  | `True`       | `False`        |
 | `atomic_configuration_update`     | `False`      | `True`         |
-| `error_on_execution`              | `True`       | `False`        |
+| `catch_errors_as_events`              | `True`       | `False`        |
 
 **Recommendation:** Use `StateChart` for new code. It follows the
 [SCXML specification](https://www.w3.org/TR/scxml/) defaults — structured error handling,
@@ -77,7 +77,7 @@ class MyMachine(StateMachine):
 ```python
 # Adopt SCXML error handling without switching to StateChart
 class MyMachine(StateMachine):
-    error_on_execution = True
+    catch_errors_as_events = True
     # ... rest of your definition unchanged
 ```
 
@@ -247,7 +247,7 @@ except TransitionNotAllowed as e:
 
 ```{tip}
 If you are migrating to `StateChart`, consider handling errors as events instead of
-catching exceptions. With `error_on_execution=True` (the default in `StateChart`),
+catching exceptions. With `catch_errors_as_events=True` (the default in `StateChart`),
 runtime errors are dispatched as `error.execution` events that you can handle with
 transitions. See {ref}`error-execution`.
 ```

--- a/statemachine/engines/base.py
+++ b/statemachine/engines/base.py
@@ -145,11 +145,11 @@ class BaseEngine:
     def _on_error_handler(self) -> "Callable[[Exception], None] | None":
         """Return a per-block error handler, or ``None``.
 
-        When ``error_on_execution`` is enabled, returns a callable that queues
+        When ``catch_errors_as_events`` is enabled, returns a callable that queues
         ``error.execution`` on the internal queue.  Otherwise returns ``None``
         so that exceptions propagate normally.
         """
-        if not self.sm.error_on_execution:
+        if not self.sm.catch_errors_as_events:
             return None
 
         def handler(error: Exception) -> None:
@@ -167,10 +167,10 @@ class BaseEngine:
     def _handle_error(self, error: Exception, trigger_data: TriggerData):
         """Handle an execution error: send ``error.execution`` or re-raise.
 
-        Centralises the ``if error_on_execution`` check so callers don't need
+        Centralises the ``if catch_errors_as_events`` check so callers don't need
         to know about the variation.
         """
-        if self.sm.error_on_execution:
+        if self.sm.catch_errors_as_events:
             self._send_error_execution(error, trigger_data)
         else:
             raise error

--- a/statemachine/io/scxml/actions.py
+++ b/statemachine/io/scxml/actions.py
@@ -334,7 +334,7 @@ def create_if_action_callable(action: IfAction) -> Callable:
                 cond_result = not cond or cond(*args, **kwargs)
             except Exception as e:
                 # SCXML spec: condition error → treat as false, queue error.execution.
-                if machine.error_on_execution:
+                if machine.catch_errors_as_events:
                     machine.send("error.execution", error=e, internal=True)
                     cond_result = False
                 else:

--- a/statemachine/statemachine.py
+++ b/statemachine/statemachine.py
@@ -94,7 +94,7 @@ class StateChart(Generic[TModel], metaclass=StateMachineMetaclass):
     execute the enter callbacks.
     """
 
-    error_on_execution: bool = True
+    catch_errors_as_events: bool = True
     """If ``True`` (default), runtime exceptions in callbacks (guards, actions, entry/exit)
     produce an ``error.execution`` internal event instead of propagating, as mandated by the
     SCXML specification. If ``False``, exceptions propagate normally."""
@@ -544,4 +544,4 @@ class StateMachine(StateChart):
     allow_event_without_transition: bool = False
     enable_self_transition_entries: bool = False
     atomic_configuration_update: bool = True
-    error_on_execution: bool = False
+    catch_errors_as_events: bool = False

--- a/tests/examples/ai_shell_machine.py
+++ b/tests/examples/ai_shell_machine.py
@@ -367,7 +367,7 @@ class AIShell(StateChart):
 
     """
 
-    error_on_execution = True
+    catch_errors_as_events = True
 
     # --- Top-level parallel state: two independent regions ---
 

--- a/tests/examples/recursive_event_machine.py
+++ b/tests/examples/recursive_event_machine.py
@@ -13,7 +13,7 @@ from statemachine import StateChart
 
 
 class MyStateMachine(StateChart):
-    error_on_execution = False
+    catch_errors_as_events = False
     startup = State(initial=True)
     test = State()
 

--- a/tests/examples/statechart_cleanup_machine.py
+++ b/tests/examples/statechart_cleanup_machine.py
@@ -5,7 +5,7 @@ Cleanup / finalize pattern
 This example demonstrates how to guarantee cleanup code runs after a transition
 **regardless of success or failure** — similar to a ``try/finally`` block.
 
-With ``StateChart`` (where ``error_on_execution=True`` by default), errors in
+With ``StateChart`` (where ``catch_errors_as_events=True`` by default), errors in
 callbacks are caught at the **block level** — meaning the microstep continues
 and ``after_<event>()`` callbacks still run. This makes ``after_<event>()`` a
 natural **finalize** hook.

--- a/tests/examples/statechart_error_handling_machine.py
+++ b/tests/examples/statechart_error_handling_machine.py
@@ -4,7 +4,7 @@ Error handling -- Quest Recovery
 
 This example demonstrates **error.execution** handling using ``StateChart``.
 
-When ``error_on_execution=True`` (the ``StateChart`` default), runtime errors in
+When ``catch_errors_as_events=True`` (the ``StateChart`` default), runtime errors in
 callbacks are caught and dispatched as ``error.execution`` events instead of
 propagating as exceptions. This lets you define error-recovery transitions.
 
@@ -78,15 +78,15 @@ assert "safe" in sm.configuration_values
 
 
 # %%
-# Comparison with error_on_execution=False (error propagation)
+# Comparison with catch_errors_as_events=False (error propagation)
 # --------------------------------------------------------------
 #
-# With ``error_on_execution=False``, the same error
+# With ``catch_errors_as_events=False``, the same error
 # would propagate as an exception instead of being caught.
 
 
 class QuestNoCatch(StateChart):
-    error_on_execution = False
+    catch_errors_as_events = False
 
     safe = State("Safe", initial=True)
     danger_zone = State("Danger Zone", final=True)

--- a/tests/examples/user_machine.py
+++ b/tests/examples/user_machine.py
@@ -64,7 +64,7 @@ class MachineChangeListenter:
 
 
 class UserStatusMachine(StateChart):
-    error_on_execution = False
+    catch_errors_as_events = False
     _states = States.from_enum(
         UserStatus,
         initial=UserStatus.signup_incomplete,

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -211,8 +211,8 @@ async def test_async_state_should_be_initialized(async_order_control_machine):
 
 
 @pytest.mark.timeout(5)
-async def test_async_error_on_execution_in_condition():
-    """Async engine catches errors in conditions with error_on_execution."""
+async def test_async_catch_errors_as_events_in_condition():
+    """Async engine catches errors in conditions with catch_errors_as_events."""
 
     class SM(StateChart):
         s1 = State(initial=True)
@@ -231,8 +231,8 @@ async def test_async_error_on_execution_in_condition():
 
 
 @pytest.mark.timeout(5)
-async def test_async_error_on_execution_in_transition():
-    """Async engine catches errors in transition callbacks with error_on_execution."""
+async def test_async_catch_errors_as_events_in_transition():
+    """Async engine catches errors in transition callbacks with catch_errors_as_events."""
 
     class SM(StateChart):
         s1 = State(initial=True)
@@ -254,8 +254,8 @@ async def test_async_error_on_execution_in_transition():
 
 
 @pytest.mark.timeout(5)
-async def test_async_error_on_execution_in_after():
-    """Async engine catches errors in after callbacks with error_on_execution."""
+async def test_async_catch_errors_as_events_in_after():
+    """Async engine catches errors in after callbacks with catch_errors_as_events."""
 
     class SM(StateChart):
         s1 = State(initial=True)
@@ -274,8 +274,8 @@ async def test_async_error_on_execution_in_after():
 
 
 @pytest.mark.timeout(5)
-async def test_async_error_on_execution_in_before():
-    """Async engine catches errors in before callbacks with error_on_execution."""
+async def test_async_catch_errors_as_events_in_before():
+    """Async engine catches errors in before callbacks with catch_errors_as_events."""
 
     class SM(StateChart):
         s1 = State(initial=True)
@@ -333,11 +333,11 @@ async def test_async_invalid_definition_in_after_propagates():
 
 
 @pytest.mark.timeout(5)
-async def test_async_runtime_error_in_after_without_error_on_execution():
-    """RuntimeError in async after callback without error_on_execution propagates."""
+async def test_async_runtime_error_in_after_without_catch_errors_as_events():
+    """RuntimeError in async after callback without catch_errors_as_events propagates."""
 
     class SM(StateChart):
-        error_on_execution = False
+        catch_errors_as_events = False
 
         s1 = State(initial=True)
         s2 = State(final=True)
@@ -353,7 +353,7 @@ async def test_async_runtime_error_in_after_without_error_on_execution():
 
 
 # --- Actual async engine tests (async callbacks trigger AsyncEngine) ---
-# Note: async engine error_on_execution with async callbacks has a known limitation:
+# Note: async engine catch_errors_as_events with async callbacks has a known limitation:
 # _send_error_execution calls sm.send() which returns an unawaited coroutine.
 # The tests below cover the paths that DO work in the async engine.
 
@@ -416,11 +416,11 @@ async def test_async_engine_invalid_definition_in_after_propagates():
 
 
 @pytest.mark.timeout(5)
-async def test_async_engine_runtime_error_in_after_without_error_on_execution_propagates():
-    """AsyncEngine: RuntimeError in async after callback without error_on_execution raises."""
+async def test_async_engine_runtime_error_in_after_without_catch_errors_as_events_propagates():
+    """AsyncEngine: RuntimeError in async after callback without catch_errors_as_events raises."""
 
     class SM(StateChart):
-        error_on_execution = False
+        catch_errors_as_events = False
 
         s1 = State(initial=True)
         s2 = State(final=True)

--- a/tests/test_async_futures.py
+++ b/tests/test_async_futures.py
@@ -90,11 +90,11 @@ class TestExceptionRouting:
 
     @pytest.mark.asyncio()
     async def test_exception_reaches_caller(self):
-        """When error_on_execution=False (not default for StateChart), the
+        """When catch_errors_as_events=False (not default for StateChart), the
         exception propagates to the caller of that event."""
 
         class FailingSC(StateChart):
-            error_on_execution = False
+            catch_errors_as_events = False
             s1 = State(initial=True)
             s2 = State(final=True)
             go = s1.to(s2)
@@ -192,17 +192,17 @@ class TestFutureEdgeCases:
         assert r2 == "result_2"
 
     @pytest.mark.asyncio()
-    async def test_concurrent_sends_exception_with_error_on_execution_off(self):
-        """When error_on_execution=False and one event raises, the exception
+    async def test_concurrent_sends_exception_with_catch_errors_as_events_off(self):
+        """When catch_errors_as_events=False and one event raises, the exception
         is routed to that caller's future; the other caller is unaffected.
 
-        With error_on_execution=False, the exception propagates and the
+        With catch_errors_as_events=False, the exception propagates and the
         processing loop clears the external queue, so the second event is
         never processed.
         """
 
         class ConcurrentFailMachine(StateChart):
-            error_on_execution = False
+            catch_errors_as_events = False
             s1 = State(initial=True)
             s2 = State()
             s3 = State(final=True)
@@ -287,7 +287,7 @@ class TestFutureEdgeCases:
         """
 
         class ValidatorSC(StateChart):
-            error_on_execution = False
+            catch_errors_as_events = False
             s1 = State(initial=True)
             s2 = State()
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -280,7 +280,7 @@ class TestIssue417:
     def sm_class(self, model_class, mock_calls):
         class ExampleStateMachine(StateChart):
             allow_event_without_transition = False
-            error_on_execution = False
+            catch_errors_as_events = False
 
             created = State(initial=True)
             started = State(final=True)
@@ -341,7 +341,7 @@ class TestIssue417:
                 return True
 
         class ExampleStateMachine(StateChart):
-            error_on_execution = False
+            catch_errors_as_events = False
 
             created = State(initial=True)
             started = State(final=True)

--- a/tests/test_conditions_algebra.py
+++ b/tests/test_conditions_algebra.py
@@ -7,7 +7,7 @@ from statemachine import StateChart
 
 class AnyConditionSM(StateChart):
     allow_event_without_transition = False
-    error_on_execution = False
+    catch_errors_as_events = False
 
     start = State(initial=True)
     end = State(final=True)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -151,7 +151,7 @@ class TestSearchProperty:
                 return False
 
         class StartMachine(StateChart):
-            error_on_execution = False
+            catch_errors_as_events = False
 
             created = State(initial=True)
             started = State(final=True)

--- a/tests/test_error_execution.py
+++ b/tests/test_error_execution.py
@@ -54,9 +54,9 @@ class ErrorInAfterSC(StateChart):
 
 
 class ErrorInGuardSM(StateChart):
-    """StateChart subclass with error_on_execution=False: exceptions should propagate."""
+    """StateChart subclass with catch_errors_as_events=False: exceptions should propagate."""
 
-    error_on_execution = False
+    catch_errors_as_events = False
 
     initial = State("initial", initial=True)
 
@@ -67,7 +67,7 @@ class ErrorInGuardSM(StateChart):
 
 
 class ErrorInActionSMWithFlag(StateChart):
-    """StateChart subclass (error_on_execution = True by default)."""
+    """StateChart subclass (catch_errors_as_events = True by default)."""
 
     s1 = State("s1", initial=True)
     s2 = State("s2")
@@ -148,7 +148,7 @@ def test_exception_in_after_sends_error_execution_no_rollback():
 
 
 def test_statemachine_exception_propagates():
-    """StateChart with error_on_execution=False should propagate exceptions normally."""
+    """StateChart with catch_errors_as_events=False should propagate exceptions normally."""
     sm = ErrorInGuardSM()
     assert sm.configuration == {sm.initial}
 
@@ -158,7 +158,7 @@ def test_statemachine_exception_propagates():
 
 
 def test_invalid_definition_always_propagates():
-    """InvalidDefinition should always propagate regardless of error_on_execution."""
+    """InvalidDefinition should always propagate regardless of catch_errors_as_events."""
 
     class BadDefinitionSC(StateChart):
         s1 = State("s1", initial=True)
@@ -190,8 +190,8 @@ def test_error_in_error_handler_no_infinite_loop():
     assert sm.configuration == {sm.s2}
 
 
-def test_statemachine_with_error_on_execution_true():
-    """StateChart (error_on_execution=True by default) should catch errors."""
+def test_statemachine_with_catch_errors_as_events_true():
+    """StateChart (catch_errors_as_events=True by default) should catch errors."""
     sm = ErrorInActionSMWithFlag()
     assert sm.configuration == {sm.s1}
 
@@ -505,7 +505,7 @@ class TestErrorConventionLOTR:
         assert sm.configuration == {sm.betrayed}
 
     def test_statemachine_with_convention_and_flag(self):
-        """StateChart (error_on_execution=True by default) uses the error_ convention."""
+        """StateChart (catch_errors_as_events=True by default) uses the error_ convention."""
 
         class SarumanBetrayal(StateChart):
             white_council = State("white_council", initial=True)
@@ -522,10 +522,10 @@ class TestErrorConventionLOTR:
         assert sm.configuration == {sm.orthanc}
 
     def test_statemachine_without_flag_propagates(self):
-        """StateChart with error_on_execution=False propagates errors even with convention."""
+        """StateChart with catch_errors_as_events=False propagates errors even with convention."""
 
         class AragornSword(StateChart):
-            error_on_execution = False
+            catch_errors_as_events = False
 
             broken = State("broken", initial=True)
 
@@ -963,11 +963,11 @@ class TestEngineErrorPropagation:
         with pytest.raises(InvalidDefinition, match="Bad after"):
             sm.send("go")
 
-    def test_runtime_error_in_after_without_error_on_execution_propagates(self):
-        """RuntimeError in after callback without error_on_execution raises."""
+    def test_runtime_error_in_after_without_catch_errors_as_events_propagates(self):
+        """RuntimeError in after callback without catch_errors_as_events raises."""
 
         class SM(StateChart):
-            error_on_execution = False
+            catch_errors_as_events = False
 
             s1 = State(initial=True)
             s2 = State(final=True)
@@ -981,8 +981,8 @@ class TestEngineErrorPropagation:
         with pytest.raises(RuntimeError, match="After boom"):
             sm.send("go")
 
-    def test_runtime_error_in_after_with_error_on_execution_handled(self):
-        """RuntimeError in after callback with error_on_execution is caught."""
+    def test_runtime_error_in_after_with_catch_errors_as_events_handled(self):
+        """RuntimeError in after callback with catch_errors_as_events is caught."""
 
         class SM(StateChart):
             s1 = State(initial=True)
@@ -999,11 +999,11 @@ class TestEngineErrorPropagation:
         sm.send("go")
         assert sm.configuration == {sm.error_state}
 
-    def test_runtime_error_in_microstep_without_error_on_execution(self):
-        """RuntimeError in microstep without error_on_execution raises."""
+    def test_runtime_error_in_microstep_without_catch_errors_as_events(self):
+        """RuntimeError in microstep without catch_errors_as_events raises."""
 
         class SM(StateChart):
-            error_on_execution = False
+            catch_errors_as_events = False
 
             s1 = State(initial=True)
             s2 = State(final=True)
@@ -1023,7 +1023,7 @@ def test_internal_queue_processes_raised_events():
     """Internal events raised during processing are handled."""
 
     class SM(StateChart):
-        error_on_execution = False
+        catch_errors_as_events = False
 
         s1 = State(initial=True)
         s2 = State()
@@ -1045,7 +1045,7 @@ def test_engine_start_when_already_started():
     """start() is a no-op when state machine is already initialized."""
 
     class SM(StateChart):
-        error_on_execution = False
+        catch_errors_as_events = False
 
         s1 = State(initial=True)
         s2 = State(final=True)
@@ -1108,11 +1108,11 @@ def test_invalid_definition_in_internal_event_propagates():
 
 
 @pytest.mark.timeout(5)
-def test_runtime_error_in_internal_event_propagates_without_error_on_execution():
-    """RuntimeError in internal event propagates when error_on_execution is False."""
+def test_runtime_error_in_internal_event_propagates_without_catch_errors_as_events():
+    """RuntimeError in internal event propagates when catch_errors_as_events is False."""
 
     class SM(StateChart):
-        error_on_execution = False
+        catch_errors_as_events = False
 
         s1 = State(initial=True)
         s2 = State()

--- a/tests/test_multiple_destinations.py
+++ b/tests/test_multiple_destinations.py
@@ -72,7 +72,7 @@ def test_do_not_transition_if_multiple_targets_with_guard():
         "A workflow"
 
         allow_event_without_transition = False
-        error_on_execution = False
+        catch_errors_as_events = False
 
         requested = State(initial=True)
         accepted = State(final=True)
@@ -102,7 +102,7 @@ def test_check_invalid_reference_to_conditions():
     class ApprovalMachine(StateChart):
         "A workflow"
 
-        error_on_execution = False
+        catch_errors_as_events = False
 
         requested = State(initial=True)
         accepted = State(final=True)
@@ -119,7 +119,7 @@ def test_should_change_to_returned_state_on_multiple_target_with_combined_transi
         "A workflow"
 
         allow_event_without_transition = False
-        error_on_execution = False
+        catch_errors_as_events = False
 
         requested = State(initial=True)
         accepted = State()
@@ -210,7 +210,7 @@ def test_multiple_values_returned_with_multiple_targets():
 )
 def test_multiple_targets_using_or_starting_from_same_origin(payment_failed, expected_state):
     class InvoiceStateMachine(StateChart):
-        error_on_execution = False
+        catch_errors_as_events = False
 
         unpaid = State(initial=True)
         paid = State(final=True)

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -8,7 +8,7 @@ from statemachine import StateChart
 
 class OrderControl(StateChart):
     allow_event_without_transition = False
-    error_on_execution = False
+    catch_errors_as_events = False
 
     waiting_for_payment = State(initial=True)
     processing = State()

--- a/tests/test_scxml_units.py
+++ b/tests/test_scxml_units.py
@@ -220,7 +220,7 @@ class TestSCXMLForeachArrayError:
         processor = SCXMLProcessor()
         processor.parse_scxml("test_foreach_error", scxml)
         sm = processor.start()
-        # The foreach array eval raises, which gets caught by error_on_execution
+        # The foreach array eval raises, which gets caught by catch_errors_as_events
         assert sm.configuration == {sm.states_map["error"]}
 
 
@@ -284,10 +284,10 @@ class TestEventDataWrapperMultipleArgs:
 
 
 class TestIfActionRaisesWithoutErrorOnExecution:
-    """SCXML <if> condition error raises when error_on_execution is False."""
+    """SCXML <if> condition error raises when catch_errors_as_events is False."""
 
-    def test_if_condition_error_propagates_without_error_on_execution(self):
-        """<if> with failing condition raises when machine.error_on_execution is False."""
+    def test_if_condition_error_propagates_without_catch_errors_as_events(self):
+        """<if> with failing condition raises when machine.catch_errors_as_events is False."""
         from statemachine.io.scxml.actions import create_if_action_callable
         from statemachine.io.scxml.schema import IfAction
         from statemachine.io.scxml.schema import IfBranch
@@ -296,7 +296,7 @@ class TestIfActionRaisesWithoutErrorOnExecution:
         if_callable = create_if_action_callable(action)
 
         machine = Mock()
-        machine.error_on_execution = False
+        machine.catch_errors_as_events = False
         machine.model.__dict__ = {}
 
         with pytest.raises(NameError, match="undefined_var"):

--- a/tests/test_statemachine_compat.py
+++ b/tests/test_statemachine_compat.py
@@ -7,7 +7,7 @@ behaviour that differs from ``StateChart`` defaults:
 - ``allow_event_without_transition = False``  → ``TransitionNotAllowed``
 - ``enable_self_transition_entries = False``
 - ``atomic_configuration_update = True``
-- ``error_on_execution = False``  → exceptions propagate directly
+- ``catch_errors_as_events = False``  → exceptions propagate directly
 - ``current_state`` deprecated property
 """
 
@@ -36,8 +36,8 @@ class TestStateMachineDefaults:
     def test_atomic_configuration_update(self):
         assert StateMachine.atomic_configuration_update is True
 
-    def test_error_on_execution(self):
-        assert StateMachine.error_on_execution is False
+    def test_catch_errors_as_events(self):
+        assert StateMachine.catch_errors_as_events is False
 
 
 # ---------------------------------------------------------------------------
@@ -219,12 +219,12 @@ class TestTransitionNotAllowedAsync:
 
 
 # ---------------------------------------------------------------------------
-# error_on_execution = False (exceptions propagate directly)
+# catch_errors_as_events = False (exceptions propagate directly)
 # ---------------------------------------------------------------------------
 
 
 class TestErrorOnExecutionFalse:
-    """With error_on_execution=False, exceptions propagate without being caught."""
+    """With catch_errors_as_events=False, exceptions propagate without being caught."""
 
     def test_runtime_error_in_action_propagates(self):
         class SM(StateMachine):

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -366,7 +366,7 @@ class TestTransitionFromAny:
     def account_sm(self):
         class AccountStateMachine(StateChart):
             allow_event_without_transition = False
-            error_on_execution = False
+            catch_errors_as_events = False
 
             active = State("Active", initial=True)
             suspended = State("Suspended")
@@ -414,7 +414,7 @@ class TestTransitionFromAny:
 
     def test_any_can_be_used_as_decorator(self):
         class AccountStateMachine(StateChart):
-            error_on_execution = False
+            catch_errors_as_events = False
 
             active = State("Active", initial=True)
             suspended = State("Suspended")

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -5,7 +5,7 @@ Unlike conditions (cond/unless), which return booleans and silently skip
 transitions, validators communicate *why* a transition was rejected.
 
 Key behavior (since v3): validator exceptions always propagate to the caller,
-regardless of the ``error_on_execution`` flag. They are NOT converted to
+regardless of the ``catch_errors_as_events`` flag. They are NOT converted to
 ``error.execution`` events — they operate in the transition-selection phase,
 not the execution phase.
 """
@@ -21,7 +21,7 @@ from statemachine import StateChart
 
 
 class OrderValidation(StateChart):
-    """StateChart with error_on_execution=True (the default)."""
+    """StateChart with catch_errors_as_events=True (the default)."""
 
     pending = State(initial=True)
     confirmed = State()
@@ -36,9 +36,9 @@ class OrderValidation(StateChart):
 
 
 class OrderValidationNoErrorEvents(StateChart):
-    """Same machine but with error_on_execution=False."""
+    """Same machine but with catch_errors_as_events=False."""
 
-    error_on_execution = False
+    catch_errors_as_events = False
 
     pending = State(initial=True)
     confirmed = State()
@@ -133,8 +133,8 @@ class ValidatorFallthrough(StateChart):
 class TestValidatorPropagation:
     """Validator exceptions always propagate to the caller."""
 
-    async def test_validator_rejects_with_error_on_execution_true(self, sm_runner):
-        """With error_on_execution=True (default), validator exceptions still
+    async def test_validator_rejects_with_catch_errors_as_events_true(self, sm_runner):
+        """With catch_errors_as_events=True (default), validator exceptions still
         propagate — they are NOT converted to error.execution events."""
         sm = await sm_runner.start(OrderValidation)
 
@@ -143,8 +143,8 @@ class TestValidatorPropagation:
 
         assert "pending" in sm.configuration_values
 
-    async def test_validator_rejects_with_error_on_execution_false(self, sm_runner):
-        """With error_on_execution=False, validator exceptions propagate
+    async def test_validator_rejects_with_catch_errors_as_events_false(self, sm_runner):
+        """With catch_errors_as_events=False, validator exceptions propagate
         (same behavior as True — validators always propagate)."""
         sm = await sm_runner.start(OrderValidationNoErrorEvents)
 
@@ -231,7 +231,7 @@ class TestValidatorWithConditions:
 class TestValidatorDoesNotTriggerErrorExecution:
     """The key semantic: validator rejection is NOT an execution error.
 
-    Even when error_on_execution=True and an error.execution transition
+    Even when catch_errors_as_events=True and an error.execution transition
     exists, a validator raising should propagate to the caller — not
     be routed through the error.execution mechanism.
     """

--- a/tests/testcases/test_issue434.py
+++ b/tests/testcases/test_issue434.py
@@ -12,7 +12,7 @@ class Model:
 
 
 class DataCheckerMachine(StateChart):
-    error_on_execution = False
+    catch_errors_as_events = False
 
     check_data = State(initial=True)
     data_good = State(final=True)


### PR DESCRIPTION
## Summary

- Renames the `error_on_execution` class attribute to `catch_errors_as_events` on both `StateChart` and `StateMachine`
- The old name read as "error on execution" (describing a problem) rather than conveying the behavior it controls
- The new name says exactly what it does: catch errors and dispatch them as `error.execution` events
- Updated across source code, engine, SCXML actions, all tests (18 files), all docs (11 files), and AGENTS.md

Closes #581