### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "develop" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fgmacedo/python-statemachine/security/code-scanning/3](https://github.com/fgmacedo/python-statemachine/security/code-scanning/3)

To fix this, explicitly declare minimal `GITHUB_TOKEN` permissions for the workflow or job. The safest approach without changing functionality is to add a `permissions` block that grants read-only access to repository contents (and anything else clearly required). This documents the requirements and ensures they remain least-privilege regardless of repo/organization defaults.

The single best fix here is to add a workflow-level `permissions` block near the top of `.github/workflows/python-package.yml`, after the `on:` block and before `jobs:`. Since the workflow only checks out code, installs dependencies, runs lint/tests, and uploads coverage via Codecov (with its own secret token), it only needs read access to repository contents. Thus we can set:

```yaml
permissions:
  contents: read
```

No additional imports or methods are needed, since this is just a YAML configuration change to the workflow file. The rest of the workflow remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
