### PR TITLE
test: fix flaky timing in test_cancel_terminated_invocation

### DIFF
--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -614,8 +614,10 @@ class TestInvokeCancelAlreadyTerminated:
             done_invoke_loading = loading.to(ready)
 
         sm = await sm_runner.start(SM)
-        await sm_runner.sleep(0.15)
-        await sm_runner.processing_loop(sm)
+        deadline = time.monotonic() + 2.0
+        while "ready" not in sm.configuration_values and time.monotonic() < deadline:
+            await sm_runner.sleep(0.02)
+            await sm_runner.processing_loop(sm)
 
         assert "ready" in sm.configuration_values
         # All invocations should be terminated by now


### PR DESCRIPTION
## Summary

- Replace fixed 150 ms `sleep` + `processing_loop` with a deadline-bounded poll (20 ms ticks, 2 s ceiling) until `ready` enters the configuration
- Same pattern used by other invoke tests is left untouched; this is the one that has been observed to flake on slower CI runners (Python 3.11 on GHA)

## Context

The CI run for the merge of `release/3.1.0` into `develop` failed on `build (3.11)`:

```
FAILED tests/test_invoke.py::TestInvokeCancelAlreadyTerminated::test_cancel_terminated_invocation[async]
AssertionError: assert 'ready' in OrderedSet(['loading'])
```

The 150 ms wasn't enough for the executor to post `done.invoke.loading` before the assertion. The test was added before 3.0.0 (#571), so this is a pre-existing flake, not a 3.1.0 regression.

Locally the new version passed 10/10 runs.