### PR TITLE
fix: skip async invoke self-cancel on own done.invoke

### DIFF
--- a/statemachine/invoke.py
+++ b/statemachine/invoke.py
@@ -526,7 +526,11 @@ class InvokeManager:
                 self._debug("%s Error in on_cancel for %s", self._log_id, invokeid, exc_info=True)
 
         # 3) Cancel the async task (raises CancelledError at next await).
-        if invocation.task is not None and not invocation.task.done():
+        if (
+            invocation.task is not None
+            and invocation.task is not asyncio.current_task()
+            and not invocation.task.done()
+        ):
             invocation.task.cancel()
 
         # 4) Wait for the sync thread to actually finish (skip if we ARE

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -214,6 +214,65 @@ class TestInvokeCancelOnExit:
         assert "cancelled_state" in sm.configuration_values
 
 
+class TestInvokeSelfCancelOnDone:
+    """Self-cancel — an invoke whose done.invoke exits the owning state must
+    not cancel itself when it completes after the initial loop releases."""
+
+    async def test_async_invoke_no_self_cancel_on_done(self):
+        import asyncio
+
+        from tests.conftest import SMRunner
+
+        sm_runner = SMRunner(is_async=True)
+        reached = []
+
+        class SM(StateChart):
+            loading = State(initial=True)
+            ready = State(final=True)
+            done_invoke_loading = loading.to(ready)
+
+            async def on_invoke_loading(self, **kwargs):
+                await asyncio.sleep(0.05)
+                return "ok"
+
+            async def on_enter_ready(self, **kwargs):
+                # Suspension point so a pending self-cancel surfaces here.
+                await asyncio.sleep(0)
+                reached.append(True)
+
+        sm = await sm_runner.start(SM)
+        await sm_runner.sleep(0.15)
+        await sm_runner.processing_loop(sm)
+
+        assert reached == [True]
+        assert "ready" in sm.configuration_values
+
+    async def test_sync_invoke_no_self_cancel_on_done(self):
+        from tests.conftest import SMRunner
+
+        sm_runner = SMRunner(is_async=False)
+        reached = []
+
+        class SM(StateChart):
+            loading = State(initial=True)
+            ready = State(final=True)
+            done_invoke_loading = loading.to(ready)
+
+            def on_invoke_loading(self, **kwargs):
+                time.sleep(0.05)
+                return "ok"
+
+            def on_enter_ready(self, **kwargs):
+                reached.append(True)
+
+        sm = await sm_runner.start(SM)
+        await sm_runner.sleep(0.15)
+        await sm_runner.processing_loop(sm)
+
+        assert reached == [True]
+        assert "ready" in sm.configuration_values
+
+
 class TestInvokeErrorHandling:
     """Error in invoker → error.execution event."""
 


### PR DESCRIPTION
On the async engine, when a state exits on its **own** `done.invoke`, `InvokeManager._cancel`
  calls `invocation.task.cancel()` unconditionally — but that task **is** the current task
  and the machine gets stuck.
  
  The sync branch already handles exactly this (step 4 skips the join when
  `invocation.thread is not threading.current_thread()` — *"skip if we ARE that thread"*).
  The async branch just missed the symmetric guard. This adds it:
  
  ```diff
           # 3) Cancel the async task (raises CancelledError at next await).
  -        if invocation.task is not None and not invocation.task.done():
  +        if (
  +            invocation.task is not None
  +            and invocation.task is not asyncio.current_task()
  +            and not invocation.task.done()
  +        ):  
               invocation.task.cancel()
  ``` 