### PR TITLE
fix(io): materialize transition validators from dict definitions

### DIFF
--- a/statemachine/io/__init__.py
+++ b/statemachine/io/__init__.py
@@ -22,7 +22,7 @@ class TransitionDict(TypedDict, total=False):
     event: "str | None"
     internal: bool
     initial: bool
-    validators: bool
+    validators: "str | ActionProtocol | Sequence[str] | Sequence[ActionProtocol]"
     cond: "str | ActionProtocol | Sequence[str] | Sequence[ActionProtocol]"
     unless: "str | ActionProtocol | Sequence[str] | Sequence[ActionProtocol]"
     on: "str | ActionProtocol | Sequence[str] | Sequence[ActionProtocol]"
@@ -191,6 +191,7 @@ def create_machine_class_from_definition(
                     "event": transition_event_name,
                     "internal": transition_data.get("internal"),
                     "initial": transition_data.get("initial"),
+                    "validators": transition_data.get("validators"),
                     "cond": transition_data.get("cond"),
                     "unless": transition_data.get("unless"),
                     "on": transition_data.get("on"),

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,5 +1,6 @@
 """Tests for statemachine.io module (dictionary-based state machine definitions)."""
 
+import pytest
 from statemachine.io import _parse_history
 from statemachine.io import create_machine_class_from_definition
 
@@ -44,3 +45,34 @@ class TestCreateMachineWithEventNameConcat:
         event_ids = sorted(e.id for e in sm.events)
         assert "parent_evt" in event_ids
         assert "sub_evt" in event_ids
+
+
+class TestTransitionValidators:
+    """A ``validators`` entry in a transition definition must be materialized
+    onto the Transition (the explicit-rejection channel), not silently dropped.
+    """
+
+    def test_validators_from_definition_run_on_send(self):
+        class Rejected(Exception):
+            pass
+
+        def reject(*args, **kwargs):
+            raise Rejected("not allowed")
+
+        sm_cls = create_machine_class_from_definition(
+            "ValidatedMachine",
+            states={
+                "s1": {
+                    "initial": True,
+                    "on": {"go": [{"target": "s2", "validators": reject}]},
+                },
+                "s2": {"final": True},
+            },
+        )
+        sm = sm_cls()
+
+        # Without the validator being materialized, send() would succeed and
+        # the machine would land in s2. With it, the validator aborts.
+        with pytest.raises(Rejected):
+            sm.send("go")
+        assert sm.current_state.id == "s1"


### PR DESCRIPTION
### What

`create_machine_class_from_definition` builds each `Transition` with `cond`, `unless`, `on`, `before`, and `after` from the definition — but dropped `validators`. So a `validators` entry in a dict/JSON definition was silently ignored and never ran at `send()`. The `TransitionDict` TypedDict also mistyped `validators` as `bool`.

This PR:
- threads `validators` through to `Transition(...)` in `create_machine_class_from_definition`;
- corrects the `TransitionDict.validators` annotation to the same callback-spec union as `cond`/`unless`;
- adds a regression test (`tests/test_io.py::TestTransitionValidators`) proving a definition-supplied validator runs and aborts on `send()` (the test fails without the production change).

### Why

`Transition.__init__` already accepts `validators=`; only the dict adapter wasn't passing it. Validators are the documented explicit-rejection channel (raise with a reason) — without this, dict/JSON-defined machines can't use it.

### Notes

- Two-line production change + type fix; no behavior change for definitions that don't set `validators`.
- `ruff check` clean; `pytest tests/test_io.py` green (4 passed).

Closes https://github.com/fgmacedo/python-statemachine/issues/628
