### PR TITLE
fix: support negative indices in OrderedSet.__getitem__

### DIFF
--- a/statemachine/orderedset.py
+++ b/statemachine/orderedset.py
@@ -62,6 +62,12 @@ class OrderedSet(MutableSet[T]):
     >>> s[2]
     3
 
+    >>> s[-1]
+    3
+
+    >>> s[-3]
+    1
+
     >>> eval(repr(OrderedSet(['a', 'b', 'c'])))
     OrderedSet(['a', 'b', 'c'])
 
@@ -84,10 +90,15 @@ class OrderedSet(MutableSet[T]):
         self._d.pop(x, None)
 
     def __getitem__(self, index) -> T:
+        original_index = index
+        if index < 0:
+            index += len(self)
+        if index < 0:
+            raise IndexError(f"index {original_index} out of range")
         try:
             return next(itertools.islice(self._d, index, index + 1))
         except StopIteration as e:
-            raise IndexError(f"index {index} out of range") from e
+            raise IndexError(f"index {original_index} out of range") from e
 
     def __contains__(self, x: object) -> bool:
         return self._d.__contains__(x)

--- a/statemachine/orderedset.py
+++ b/statemachine/orderedset.py
@@ -71,8 +71,6 @@ class OrderedSet(MutableSet[T]):
     >>> eval(repr(OrderedSet(['a', 'b', 'c'])))
     OrderedSet(['a', 'b', 'c'])
 
-
-
     """
 
     __slots__ = ("_d",)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -56,11 +56,26 @@ def test_ordered_set_getitem():
     assert s[2] == 30
 
 
+def test_ordered_set_getitem_negative_index():
+    """OrderedSet supports negative index access like Python sequences."""
+    s = OrderedSet([10, 20, 30])
+    assert s[-1] == 30
+    assert s[-2] == 20
+    assert s[-3] == 10
+
+
 def test_ordered_set_getitem_out_of_range():
     """OrderedSet raises IndexError for out-of-range index."""
     s = OrderedSet([10, 20])
     with pytest.raises(IndexError, match="index 5 out of range"):
         s[5]
+
+
+def test_ordered_set_getitem_negative_out_of_range():
+    """OrderedSet raises IndexError for negative out-of-range index."""
+    s = OrderedSet([10, 20])
+    with pytest.raises(IndexError, match=r"index -3 out of range"):
+        s[-3]
 
 
 def test_ordered_set_union():


### PR DESCRIPTION
## What

`OrderedSet.__getitem__` raised `ValueError` (from `itertools.islice`) when called with a negative index, instead of the `IndexError` callers expect — or, better, returning the element counting from the end, as all Python sequences do.

```python
s = OrderedSet([1, 2, 3])
s[-1]  # ValueError: Indices for islice() must be None or an integer: 0 <= x <= sys.maxsize.
```

## Why

`itertools.islice` rejects negative start/stop values with `ValueError`. Since `__getitem__` is documented and exported as a sequence-style accessor (positive indices already work, positive out-of-range already raises `IndexError`), negative indices should follow the same contract as Python's built-in sequences.

## Fix

Normalise the index before delegating to `islice`:
- if `index < 0`, add `len(self)` to convert it to the equivalent positive offset
- if still negative after normalisation, raise `IndexError` with the original index in the message (not the normalised value)

```python
s[-1]  # 3  ✓
s[-3]  # 1  ✓
s[-4]  # IndexError: index -4 out of range  ✓
```

Two new unit tests cover the happy path and the out-of-range case. Doctests in `orderedset.py` are updated with examples of `s[-1]` and `s[-3]`.

This pull request was prepared with the assistance of AI, under my direction and review.